### PR TITLE
Fix bug where pressing Enter routes to invalid slug

### DIFF
--- a/src/components/SearchableRegionList.tsx
+++ b/src/components/SearchableRegionList.tsx
@@ -67,9 +67,9 @@ export default function SearchableRegionList({
         case 'Enter':
           e.preventDefault();
           if (selectedIndex >= 0 && selectedIndex < filteredRegions.length) {
-            const selectedSlug = filteredRegions[selectedIndex];
+            const { slug } = filteredRegions[selectedIndex];
             setIsLoading(true);
-            router.push(`/regions/${selectedSlug}`);
+            router.push(`/regions/${slug}`);
           }
           break;
         case 'Escape':


### PR DESCRIPTION
Fixes #9 

The issue was that `filteredRegions[selectedIndex]` was a region object, so we needed to grab the `slug` off of there in the keypress handler.