### PR TITLE
Rename job from "build" to "run-tests"

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ on:
       - synchronize
       - reopened
 jobs:
-  build:
+  run-tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
@pstaylor-patrick I saw in your screencast the confusion about the job name being `build`. I think this is where it's being defined. I assumed that the `build` key in that object was defining how the job was built, but it looks like it's actually using that as the name of the job. This should change it to `run-tests` 👍 