### PR TITLE
Fix #20

### DIFF
--- a/src/components/SearchableRegionList.tsx
+++ b/src/components/SearchableRegionList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, KeyboardEvent, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, KeyboardEvent, useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ALL_LETTERS } from '@/lib/const';
@@ -48,6 +48,10 @@ export default function SearchableRegionList({
     },
     [router]
   );
+
+  useEffect(() => {
+    if(filteredRegions.length === 1) setSelectedIndex(0); 
+  }, [filteredRegions]);  
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## What does this PR do?

This pull request addresses issue #20  – *"When Search Returns Only One Result, Enter Key Should Navigate to It By Default."*  
It sets the `selectedIndex` to `0` when there is only one search result.

## Why is this needed?

Previously, if the search returned a single result, pressing Enter did not automatically select it. This change ensures that when there is only one filtered region, it is selected by default, improving usability and reducing the number of required keystrokes.

## How was this tested?

Manually tested by entering various search terms and confirming that pressing Enter navigates directly to the result when only one option is returned.
