### PR TITLE
exclude special characters from region slugs

### DIFF
--- a/src/utils/toKebabCase.ts
+++ b/src/utils/toKebabCase.ts
@@ -1,5 +1,5 @@
 export const toKebabCase = (str: string) =>
   str
     .toLowerCase()
-    .replace(/\s+/g, '-')
+    .replace(/[\s-]+/g, '-')
     .replace(/[^a-z0-9-]/g, '');


### PR DESCRIPTION
### TL;DR

This PR resolves the issue where region slugs contained multiple consecutive hyphens due to special characters and whitespace in region names. For example, a region named "F3 Redmond - WA" was generating the slug `redmond---wa`.

To fix this, a `.replace(/-{3,}/g, '-')` was added to seed.ts after the function KebabCase to collapse sequences of 3 or more hyphens into a single hyphen, resulting in cleaner slugs like `redmond-wa`.

### Details

resolves https://github.com/F3-Nation/f3-region-pages/issues/24

(coming soon)

### How to Test

(coming soon)

### GIF

![tabs-or-spaces](https://github.com/user-attachments/assets/be3399bd-72ba-431a-8cfc-52f5ceba6168)
