### PR TITLE
fix workout type matching

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -112,7 +112,6 @@ async function* fetchWorkouts(): AsyncGenerator<Workout> {
     .where(eq(eventsSchema.isActive, true))
     .orderBy(asc(eventsSchema.name));
 
-  const types = ['bootcamp', 'ruck', 'run', 'sandbag'];
   for await (const workout of workouts) {
     const [workoutTypeLkp] = await f3DataWarehouseDb
       .select()


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of are series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Improved the workout seeding logic to use event type mappings from the data warehouse, ensuring more accurate workout type assignment and making the seeding process idempotent.

### 🔎 Details

- Updated `scripts/seed.ts` to:
  - Use the `eventsXEventTypes` and `eventTypes` tables to determine workout types instead of inferring from notes.
  - Make the seeding process idempotent by using `onConflictDoUpdate` for workouts, updating existing records if they already exist.
  - Removed logic that skipped previously ingested workouts; now all active workouts are considered, and existing ones are updated.
  - Added warnings if a workout type mapping or event type is missing for a workout.
  - The `type` field for workouts is now set from the event type name, not guessed from notes.

### ✅ How to Test

1. Run the seed script: `pnpm tsx scripts/seed.ts` (or your preferred method).
2. Confirm that all active workouts from the data warehouse are inserted or updated in your local database.
3. Check that the `type` field for each workout matches the event type from the warehouse, not just a default or guessed value.
4. Review logs for any warnings about missing workout type mappings or event types.
5. Re-run the seed script to verify that it updates existing workouts without creating duplicates.

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
