### PR TITLE
allow 24-48 hours

### DIFF
--- a/src/components/RegionContent.tsx
+++ b/src/components/RegionContent.tsx
@@ -124,7 +124,7 @@ export function OrphanedRegionContent({ region }: OrphanedRegionContentProps) {
           Add AOs on the F3 Nation Map Admin
         </a>
         <div className="text-yellow-700 dark:text-yellow-300 text-sm mt-2">
-          Allow ~15&nbsp;minutes for new locations to appear here.
+          Allow 24-48 hours for new locations to appear here.
         </div>
       </div>
 


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

The message about how long it takes for new locations to appear was updated from "Allow ~15 minutes for new locations to appear here." to "Allow 24-48 hours for new locations to appear here."

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

This PR updates the user-facing guidance in RegionContent.tsx. Previously, users were told to allow about 15 minutes for new locations to appear. The message now instructs users to allow 24-48 hours, reflecting a more accurate timeframe for data propagation. No other logic or UI was changed.

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

1. Go to a region page where no locations exist (triggers the OrphanedRegionContent component).
3. Observe the informational message below the "Add AOs on the F3 Nation Map Admin" link.
4. Confirm that it now reads: "Allow 24-48 hours for new locations to appear here." instead of the previous "~15 minutes" message.

P.S. https://regions.f3nation.com/bali is a good example at the time of this PR but if you ever want to find one just search "zip" and you'll find a region with no locations/workouts

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
