### PR TITLE
updated orphaned region cta

### DIFF
--- a/src/components/RegionContent.tsx
+++ b/src/components/RegionContent.tsx
@@ -116,15 +116,15 @@ export function OrphanedRegionContent({ region }: OrphanedRegionContentProps) {
           grow by adding new workout locations (AOs).
         </div>
         <a
-          href="https://map.f3nation.com/admin/aos"
+          href="https://docs.google.com/document/d/1ssUnIRTfteZH8GcV8K8x0c1q-cGfCu72CdhTIXSJnWI/edit?tab=t.0#heading=h.39rghinjgybm"
           className="inline-block px-5 py-2 bg-yellow-500 hover:bg-yellow-600 text-white rounded-lg font-medium transition-colors text-base shadow-md"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Add AOs on the F3 Nation Map Admin
+          Get Access to Add AOs
         </a>
         <div className="text-yellow-700 dark:text-yellow-300 text-sm mt-2">
-          Allow 24-48 hours for new locations to appear here.
+          Follow the Getting Access guide to add new workout locations.
         </div>
       </div>
 


### PR DESCRIPTION
### 👋 TL;DR

Update the “Add AOs” call-to-action on orphaned region pages to point to the Getting Access guide (Google Doc) instead of the F3 Nation Map Admin, and clarify the accompanying instruction text.

### 🔎 Details

- **What changed**  
  - The “Add AOs on the F3 Nation Map Admin” button now reads **Get Access to Add AOs** and links to our Google Doc’s Getting Access section:  
    `https://docs.google.com/document/d/1ssUnIRTfteZH8GcV8K8x0c1q-cGfCu72CdhTIXSJnWI/edit?tab=t.0#heading=h.39rghinjgybm`  
  - The helper text below the button now directs users to follow the Getting Access guide, rather than warning about a 24–48 hour delay.

- **Why**  
  - Users without admin privileges were landing on the Map Admin and getting confused.  
  - Pointing them to the step-by-step access guide (with FAQs) ensures they know how to request and gain the proper permissions before attempting to add AOs.

- **Context**  
  - Loom walkthrough (0:00–0:37) demonstrates clicking the orphaned region button for Bali, redirecting to the Getting Access guide instead of the admin UI.

### ✅ How to Test

1. Go to any orphaned region page (e.g. search “Bali” under Regions → Orphaned Regions).  
2. Verify the primary button reads **Get Access to Add AOs**.  
3. Click the button and confirm it opens the Google Doc at the “Getting Access” heading.  
4. Check that the sub-text under the button now says:  
   > Follow the Getting Access guide to add new workout locations.  
5. Ensure styling, focus/hover states, and `target="_blank" rel="noopener noreferrer"` behavior remain intact.

### 🥜 GIF

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
