### PR TITLE
implement google analytics

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { SITE_CONFIG } from '@/constants';
 import { ChunkErrorRecovery } from '@/components/ChunkErrorRecovery';
+import Script from 'next/script';
 import './globals.css';
 
 const geistSans = Geist({
@@ -53,6 +54,18 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-full bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`}
       >
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-44DEXNRMCP"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-44DEXNRMCP');
+          `}
+        </Script>
         <ChunkErrorRecovery />
         {children}
       </body>


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Added Google Analytics tracking to the application layout using Next.js Script component.

<div>
    <a href="https://www.loom.com/share/9539b7c813c242408378c9112377c54c">
      <p>F3 Region Pages - Implement google Analytics (101325) - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/9539b7c813c242408378c9112377c54c">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/9539b7c813c242408378c9112377c54c-ea1220a6c155addb-full-play.gif">
    </a>
  </div>

### 🔎 Details

This PR integrates Google Analytics (GA4) tracking by adding the required scripts to the root layout. The implementation uses Next.js Script component with `afterInteractive` strategy for optimal performance. The tracking ID `G-44DEXNRMCP` is configured to initialize GA4 when the page becomes interactive.

### ✅ How to Test

1. Build and run the application locally
2. Open browser developer tools and check the Network tab
3. Verify that `gtag.js` is loaded from Google's CDN
4. Confirm that the Google Analytics configuration script executes without errors
5. Check that page views are being recorded in Google Analytics real-time reports
6. Test navigation between different pages to ensure tracking works across the application

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
