### PR TITLE
feat: remove The Anvil CSAUP event from region events

### DIFF
--- a/src/data/region-events.json
+++ b/src/data/region-events.json
@@ -4,49 +4,6 @@
     "regionName": "F3 Muletown",
     "events": [
       {
-        "id": "ad17c38f64b2",
-        "slugSuffix": "the-anvil-csaup",
-        "legacySlugs": ["the-anvil-csaup"],
-        "title": "The Anvil CSAUP",
-        "headline": "Team-based CSAUP challenge at Riverwalk Park.",
-        "date": "2025-11-15",
-        "startTime": "05:00",
-        "endTime": "07:00",
-        "type": "CSAUP",
-        "location": {
-          "name": "Riverwalk Park Basketball Court",
-          "address": "102 Riverside Dr, Columbia, TN 38401, United States",
-          "url": "https://www.google.com/maps?q=35.6179879,-87.0305082",
-          "notes": "Look for the basketball courts near the river. Plenty of parking on site."
-        },
-        "summary": "Lock in for a two-hour CSAUP where the first evolution sorts teammates and sets the tone for a sharpened morning on the river.",
-        "highlights": [
-          "Kickoff promptly at 0500—show up warmed up and ready.",
-          "Initial THANG determines your squad for the remainder of the event.",
-          "Expect time hacks, consequences, and plenty of sharpening."
-        ],
-        "schedule": [
-          {
-            "label": "CSAUP Beatdown",
-            "time": "06:00"
-          },
-          {
-            "label": "COT",
-            "time": "07:00"
-          }
-        ],
-        "contacts": [
-          {
-            "name": "Jugs",
-            "role": "Event Q"
-          }
-        ],
-        "cta": {
-          "label": "RSVP in Slack",
-          "url": "https://join.slack.com/t/f3muletown/shared_invite/zt-3h2yz6376-WRaCBdah41v6s6sRMUs_Ng"
-        }
-      },
-      {
         "id": "175482b5481d",
         "slugSuffix": "four-years-strong",
         "legacySlugs": ["four-years-strong"],


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Remove The Anvil CSAUP event from region events data file.

### 🔎 Details

This PR removes the "The Anvil CSAUP" event entry from the `src/data/region-events.json` file. The event appears to have been cancelled or is no longer scheduled. All other events in the file remain unchanged.

### ✅ How to Test

1. Verify that the "The Anvil CSAUP" event no longer appears in the application's event listings
2. Confirm that all other events continue to display correctly
3. Check that the application handles the updated JSON structure without errors
4. Validate that any event-dependent functionality (filtering, sorting, etc.) works as expected with the reduced dataset

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
