### PR TITLE
Adding Region Pages Cloud Connector Access

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -2,6 +2,14 @@
 POSTGRES_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 F3_DATA_WAREHOUSE_URL="postgresql://[user]:[password]@[host]:[port]/[database]"
 
+# Cloud SQL Connector (set WAREHOUSE_DB_CONNECTION_MODE=connector to use instead of F3_DATA_WAREHOUSE_URL)
+# WAREHOUSE_DB_CONNECTION_MODE="direct"
+# CLOUD_SQL_WAREHOUSE_CONNECTION_NAME="project:region:instance"
+# WAREHOUSE_DB_USER=""
+# WAREHOUSE_DB_PASSWORD=""
+# WAREHOUSE_DB_NAME=""
+# CLOUD_SQL_WAREHOUSE_IP_TYPE="PUBLIC"
+
 # Cron endpoint authentication
 CRON_SECRET=your-secret-key-here
 

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -23,6 +23,30 @@ env:
       - BUILD
       - RUNTIME
 
+  # Cloud SQL Connector settings (set WAREHOUSE_DB_CONNECTION_MODE=connector to use)
+  - variable: WAREHOUSE_DB_CONNECTION_MODE
+    value: connector
+
+  - variable: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME
+    secret: cloud-sql-warehouse-connection-name
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_USER
+    secret: warehouse-db-user
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_PASSWORD
+    secret: warehouse-db-password
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_NAME
+    secret: warehouse-db-name
+    availability:
+      - RUNTIME
+
   - variable: CRON_SECRET
     secret: cron-secret
     availability:

--- a/drizzle/f3-data-warehouse/db.ts
+++ b/drizzle/f3-data-warehouse/db.ts
@@ -1,18 +1,118 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
+import type { IpAddressTypes } from '@google-cloud/cloud-sql-connector';
 import { loadEnvConfig } from '@/lib/env';
 import * as schema from './schema';
 
-// Load environment variables
-const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
+let pool: Pool | null = null;
+let connector: InstanceType<
+  typeof import('@google-cloud/cloud-sql-connector').Connector
+> | null = null;
+let dbInstance: NodePgDatabase<typeof schema> | null = null;
 
-// Create PostgreSQL connection pool
-const pool = new Pool({
-  connectionString: F3_DATA_WAREHOUSE_URL,
-});
+/**
+ * Creates a pool using the Cloud SQL Node.js Connector.
+ * Requires: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, WAREHOUSE_DB_NAME
+ */
+async function createCloudSqlPool(): Promise<Pool> {
+  const { Connector, IpAddressTypes: IpAddressTypesValues } =
+    await import('@google-cloud/cloud-sql-connector');
 
-// Create drizzle database instance
-export const db = drizzle(pool, { schema });
+  const instanceConnectionName =
+    process.env.CLOUD_SQL_WAREHOUSE_CONNECTION_NAME;
+  const dbUser = process.env.WAREHOUSE_DB_USER;
+  const dbPassword = process.env.WAREHOUSE_DB_PASSWORD;
+  const dbName = process.env.WAREHOUSE_DB_NAME;
 
-// Export for use in scripts
-export const getPool = () => pool;
+  if (!instanceConnectionName || !dbUser || !dbName) {
+    throw new Error(
+      'Cloud SQL Connector requires CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, and WAREHOUSE_DB_NAME.'
+    );
+  }
+
+  const validTypes = Object.values(IpAddressTypesValues) as string[];
+  const ipAddressType = validTypes.includes(
+    process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE ?? ''
+  )
+    ? (process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE as IpAddressTypes)
+    : IpAddressTypesValues.PUBLIC;
+
+  connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName,
+    ipType: ipAddressType,
+  });
+
+  const newPool = new Pool({
+    ...clientOpts,
+    user: dbUser,
+    password: dbPassword,
+    database: dbName,
+    max: 10,
+  });
+
+  newPool.on('error', (err) => {
+    console.error('Unexpected error on idle PostgreSQL client:', err);
+  });
+
+  console.log(
+    `PostgreSQL pool initialized via Cloud SQL Connector (${instanceConnectionName}).`
+  );
+  return newPool;
+}
+
+/**
+ * Creates a pool using a direct TCP connection via F3_DATA_WAREHOUSE_URL.
+ */
+function createDirectPool(): Pool {
+  const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
+
+  const newPool = new Pool({
+    connectionString: F3_DATA_WAREHOUSE_URL,
+  });
+
+  newPool.on('error', (err) => {
+    console.error('Unexpected error on idle PostgreSQL client:', err);
+  });
+
+  return newPool;
+}
+
+/**
+ * Returns a cached Drizzle database instance for the F3 Data Warehouse.
+ *
+ * Connection mode is controlled by WAREHOUSE_DB_CONNECTION_MODE:
+ *   "connector" → Cloud SQL Node.js Connector (authenticated, no public IP needed)
+ *   "direct"    → F3_DATA_WAREHOUSE_URL TCP connection (default)
+ */
+export async function getDb(): Promise<NodePgDatabase<typeof schema>> {
+  if (dbInstance) return dbInstance;
+
+  const mode = process.env.WAREHOUSE_DB_CONNECTION_MODE ?? 'direct';
+
+  if (mode === 'connector') {
+    pool = await createCloudSqlPool();
+  } else {
+    pool = createDirectPool();
+  }
+
+  dbInstance = drizzle(pool, { schema });
+  return dbInstance;
+}
+
+export async function getPool(): Promise<Pool> {
+  if (!pool) await getDb();
+  return pool!;
+}
+
+export async function close(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+  if (connector) {
+    connector.close();
+    connector = null;
+  }
+  dbInstance = null;
+}

--- a/drizzle/f3-data-warehouse/db.ts
+++ b/drizzle/f3-data-warehouse/db.ts
@@ -15,8 +15,9 @@ let dbInstance: NodePgDatabase<typeof schema> | null = null;
  * Requires: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, WAREHOUSE_DB_NAME
  */
 async function createCloudSqlPool(): Promise<Pool> {
-  const { Connector, IpAddressTypes: IpAddressTypesValues } =
-    await import('@google-cloud/cloud-sql-connector');
+  const { Connector, IpAddressTypes: IpAddressTypesValues } = await import(
+    '@google-cloud/cloud-sql-connector'
+  );
 
   const instanceConnectionName =
     process.env.CLOUD_SQL_WAREHOUSE_CONNECTION_NAME;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postinstall": "pnpm skills:check"
   },
   "dependencies": {
+    "@google-cloud/cloud-sql-connector": "^1.4.1",
     "dotenv": "^16.4.7",
     "lodash": "^4.17.21",
     "next": "15.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google-cloud/cloud-sql-connector':
+        specifier: ^1.4.1
+        version: 1.8.4
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1

--- a/scripts/prune-regions.ts
+++ b/scripts/prune-regions.ts
@@ -5,12 +5,13 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { orgs as orgsSchema } from '../drizzle/f3-data-warehouse/schema';
 
 export async function pruneRegions() {
   console.debug('🔄 pruning regions no longer in the warehouse...');
 
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const activeWarehouseRegions = await f3DataWarehouseDb
     .select({
       id: orgsSchema.id,

--- a/scripts/prune-workouts.ts
+++ b/scripts/prune-workouts.ts
@@ -5,12 +5,13 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { events as eventsSchema } from '../drizzle/f3-data-warehouse/schema';
 
 export async function pruneWorkouts() {
   console.debug('🔄 pruning workouts no longer in the warehouse...');
 
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const activeWarehouseWorkouts = await f3DataWarehouseDb
     .select({
       id: eventsSchema.id,

--- a/scripts/seed-regions.ts
+++ b/scripts/seed-regions.ts
@@ -3,7 +3,7 @@ import { kebabCase } from 'lodash';
 
 import { db } from '../drizzle/db';
 import { regions as regionsSchema } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { orgs as orgsSchema } from '../drizzle/f3-data-warehouse/schema';
 import { currentIngestedAt, isFresh } from './seed-state';
 
@@ -149,6 +149,7 @@ function transformInstagramUrl(instagram: string | null): string | null {
 }
 
 async function* fetchRegions(): AsyncGenerator<Region> {
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const regions = await f3DataWarehouseDb
     .select({
       id: orgsSchema.id,

--- a/scripts/seed-workouts.ts
+++ b/scripts/seed-workouts.ts
@@ -5,7 +5,7 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import {
   orgs as orgsSchema,
   events as eventsSchema,
@@ -296,6 +296,7 @@ type FetchBatchArgs = {
 };
 
 async function fetchWorkoutsBatch(args: FetchBatchArgs): Promise<BatchResult> {
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const conditions = [eq(eventsSchema.isActive, true)];
   if (args.updatedAfter) {
     conditions.push(gte(eventsSchema.updated, args.updatedAfter));

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,13 +8,14 @@ export function loadEnvConfig() {
     throw new Error(`POSTGRES_URL is not set in .env.${env}`);
   }
 
-  if (!process.env.F3_DATA_WAREHOUSE_URL) {
+  const warehouseMode = process.env.WAREHOUSE_DB_CONNECTION_MODE ?? 'direct';
+  if (warehouseMode === 'direct' && !process.env.F3_DATA_WAREHOUSE_URL) {
     throw new Error(`F3_DATA_WAREHOUSE_URL is not set in .env.${env}`);
   }
 
   return {
     POSTGRES_URL: process.env.POSTGRES_URL,
-    F3_DATA_WAREHOUSE_URL: process.env.F3_DATA_WAREHOUSE_URL,
+    F3_DATA_WAREHOUSE_URL: process.env.F3_DATA_WAREHOUSE_URL ?? '',
     NODE_ENV: env,
   };
 }


### PR DESCRIPTION
This pull request adds support for connecting to the F3 Data Warehouse using the Google Cloud SQL Node.js Connector, making it possible to use secure, authenticated connections without exposing a public IP. The changes introduce new environment variables and update the database connection logic to support both direct and connector-based modes. Several scripts and configuration files are updated to use the new connection method.

### 👋 TL;DR

Adding another way to connect to the F3 SQL db after we locked down IP access.

### 🔎 Details

This pull request introduces support for connecting to the F3 Data Warehouse using the Google Cloud SQL Node.js Connector, in addition to the existing direct TCP connection. It adds configuration options and secrets for Cloud SQL, updates database access patterns to support both modes, and refactors scripts to use the new connection method. The most important changes are grouped below:

**Cloud SQL Connector integration:**

* Added conditional logic in `drizzle/f3-data-warehouse/db.ts` to support connecting to the warehouse via the Google Cloud SQL Node.js Connector when `WAREHOUSE_DB_CONNECTION_MODE` is set to `"connector"`, including pool management, environment variable validation, and resource cleanup.
* Updated `.env.local.sample`, `apphosting.yaml`, and `package.json` to add environment variables and secrets required for Cloud SQL connections and to install the `@google-cloud/cloud-sql-connector` dependency. [[1]](diffhunk://#diff-aa29fbbd3836acca1f42a768c116ec7f0e8c1c8a4b9b4a9e73059100aa71252cR5-R12) [[2]](diffhunk://#diff-cb36c79d2ed72541b41f76be64703d96eb9906240b17a7a785b1dd6e54e736ddR26-R49) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13)

**Script and codebase refactoring:**

* Refactored all scripts and code that previously imported `db` from `drizzle/f3-data-warehouse/db` to instead use the new `getDb` async function, ensuring compatibility with both direct and Cloud SQL connection modes. [[1]](diffhunk://#diff-7b822be11f3eaa97ec4972703370fb1782a7fd5dceb7c908e52ff5ba1b199ad9L8-R14) [[2]](diffhunk://#diff-aa9b8e12cd09f1743d0b9d0f56f8f2f0ced483b2f6a49aca67e5e6b3607b4d53L8-R14) [[3]](diffhunk://#diff-f9b804fa13a419f576555651927bff0a254d48a31f05ddd898e395aa25b3f5d2L6-R6) [[4]](diffhunk://#diff-f9b804fa13a419f576555651927bff0a254d48a31f05ddd898e395aa25b3f5d2R152) [[5]](diffhunk://#diff-3eeefb0700c3df4a577dc267c7a2a326f8d26c021e13fd91ea21ff12cd574780L8-R8) [[6]](diffhunk://#diff-3eeefb0700c3df4a577dc267c7a2a326f8d26c021e13fd91ea21ff12cd574780R299)

**Environment configuration validation:**

* Updated `src/lib/env.ts` to validate `F3_DATA_WAREHOUSE_URL` only when using direct mode, allowing Cloud SQL connector mode to skip this check.