### PR TITLE
Hotfix: Fix ETIMEDOUT ingest failures with Cloud SQL connector, RetryPool, and pool hardening

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -2,6 +2,14 @@
 POSTGRES_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 F3_DATA_WAREHOUSE_URL="postgresql://[user]:[password]@[host]:[port]/[database]"
 
+# Cloud SQL Connector (set WAREHOUSE_DB_CONNECTION_MODE=connector to use instead of F3_DATA_WAREHOUSE_URL)
+# WAREHOUSE_DB_CONNECTION_MODE="direct"
+# CLOUD_SQL_WAREHOUSE_CONNECTION_NAME="f3data:us-central1:f3data"
+# WAREHOUSE_DB_USER=""
+# WAREHOUSE_DB_PASSWORD=""
+# WAREHOUSE_DB_NAME=""
+# CLOUD_SQL_WAREHOUSE_IP_TYPE="PUBLIC"
+
 # Cron endpoint authentication
 CRON_SECRET=your-secret-key-here
 

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -23,6 +23,30 @@ env:
       - BUILD
       - RUNTIME
 
+  # Cloud SQL Connector settings (set WAREHOUSE_DB_CONNECTION_MODE=connector to use)
+  - variable: WAREHOUSE_DB_CONNECTION_MODE
+    value: connector
+
+  - variable: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME
+    secret: cloud-sql-warehouse-connection-name
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_USER
+    secret: warehouse-db-user
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_PASSWORD
+    secret: warehouse-db-password
+    availability:
+      - RUNTIME
+
+  - variable: WAREHOUSE_DB_NAME
+    secret: warehouse-db-name
+    availability:
+      - RUNTIME
+
   - variable: CRON_SECRET
     secret: cron-secret
     availability:

--- a/docs/postmortems/2026-04-06-etimedout-ingest-failures.md
+++ b/docs/postmortems/2026-04-06-etimedout-ingest-failures.md
@@ -1,0 +1,57 @@
+# Post-Mortem: ETIMEDOUT Errors in Daily Ingest
+
+**Date:** 2026-04-06
+**Severity:** High
+**Duration:** Multiple days (intermittent failures)
+**Author:** Patrick Taylor
+
+---
+
+## Summary
+
+The daily data ingest process experienced persistent ETIMEDOUT errors when connecting to the F3 Data Warehouse (hosted on Google Cloud Platform). This caused the ingest pipeline to fail, preventing region and workout data from syncing to the production database.
+
+## Root Cause
+
+Both database connection pools (Supabase and F3 Data Warehouse) were initialized using the default `pg` Pool configuration with no explicit connection limits, timeouts, or statement timeouts.
+
+The default `pg` Pool settings allow up to 10 concurrent connections with no idle timeout, no connection timeout, and no statement timeout. During the seed-workouts phase, 8 concurrent upsert operations (the default `UPSERT_CONCURRENCY`) would attempt to acquire connections from both pools simultaneously. Under load, this exhausted the GCP warehouse's connection capacity, causing new connection attempts to hang indefinitely until the operating system killed them with ETIMEDOUT.
+
+Key contributing factors:
+- **No explicit pool sizing**: Default `pg` Pool allows ~10 connections, but with 8 concurrent workers each needing connections from both pools, effective demand was up to 16 concurrent connections across two pools
+- **No connection timeout**: Failed connection attempts hung indefinitely rather than failing fast
+- **No idle timeout**: Stale connections were never released back to the pool
+- **No statement timeout**: Long-running queries could hold connections indefinitely
+- **GCP warehouse constraints**: The warehouse is hosted on GCP with unknown connection limits that we cannot modify
+
+## Mitigation
+
+### Immediate Fixes (this PR)
+
+1. **Extracted pool configuration into a testable module** (`drizzle/pool-config.ts`)
+   - Warehouse pool: max 5 connections, 10s idle/connect timeout, 30s statement timeout
+   - Supabase pool: max 10 connections, 10s idle/connect timeout, 60s statement timeout
+
+2. **Applied explicit pool configuration** to both database connections
+   - `drizzle/f3-data-warehouse/db.ts` — warehouse pool with conservative limits
+   - `drizzle/db.ts` — Supabase pool with moderate limits
+
+3. **Reduced default upsert concurrency** from 8 to 4 (`scripts/seed-workouts.ts`)
+   - Ensures concurrent operations stay well within pool limits
+   - Still configurable via `WORKOUT_SEED_UPSERT_CONCURRENCY` env var
+
+4. **Added tests** for pool configuration constraints and concurrency defaults
+
+### Additional Fixes (cherry-picked)
+
+5. **Prune workouts when parent AO is deactivated** — Previously, workouts were orphaned when their parent AO was deactivated, causing stale data to accumulate
+6. **Fixed SQL filter syntax** — Corrected missing comma in multi-condition filter
+7. **Wrapped ingest handler preamble in try/catch** — Database errors during the idempotency check and initial run tracking now send Slack notifications instead of failing silently
+
+## Prevention
+
+- [ ] Pool configuration is now explicitly defined and tested — any regression will be caught by the test suite
+- [ ] Concurrency defaults are validated by tests
+- [ ] Connection and statement timeouts ensure fail-fast behavior rather than indefinite hangs
+- [ ] Slack notification coverage expanded to catch preamble errors that previously failed silently
+- [ ] Consider adding connection pool metrics/logging in a future iteration to monitor pool utilization over time

--- a/docs/postmortems/2026-04-06-etimedout-ingest-failures.md
+++ b/docs/postmortems/2026-04-06-etimedout-ingest-failures.md
@@ -18,6 +18,7 @@ Both database connection pools (Supabase and F3 Data Warehouse) were initialized
 The default `pg` Pool settings allow up to 10 concurrent connections with no idle timeout, no connection timeout, and no statement timeout. During the seed-workouts phase, 8 concurrent upsert operations (the default `UPSERT_CONCURRENCY`) would attempt to acquire connections from both pools simultaneously. Under load, this exhausted the GCP warehouse's connection capacity, causing new connection attempts to hang indefinitely until the operating system killed them with ETIMEDOUT.
 
 Key contributing factors:
+
 - **No explicit pool sizing**: Default `pg` Pool allows ~10 connections, but with 8 concurrent workers each needing connections from both pools, effective demand was up to 16 concurrent connections across two pools
 - **No connection timeout**: Failed connection attempts hung indefinitely rather than failing fast
 - **No idle timeout**: Stale connections were never released back to the pool

--- a/drizzle.config.warehouse.ts
+++ b/drizzle.config.warehouse.ts
@@ -3,6 +3,12 @@ import { loadEnvConfig } from '@/lib/env';
 
 const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
 
+if (!F3_DATA_WAREHOUSE_URL) {
+  throw new Error(
+    'F3_DATA_WAREHOUSE_URL is required for warehouse config (set WAREHOUSE_DB_CONNECTION_MODE=direct)'
+  );
+}
+
 export default defineConfig({
   schema: './drizzle/migrations/warehouse-schema.ts',
   out: './drizzle/migrations',

--- a/drizzle/db.ts
+++ b/drizzle/db.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { loadEnvConfig } from '@/lib/env';
+import { SUPABASE_POOL_CONFIG } from './pool-config';
 import * as schema from './schema';
 
 // Load environment variables
@@ -9,6 +10,7 @@ const { POSTGRES_URL } = loadEnvConfig();
 // Create PostgreSQL connection pool
 const pool = new Pool({
   connectionString: POSTGRES_URL,
+  ...SUPABASE_POOL_CONFIG,
 });
 
 // Create drizzle database instance

--- a/drizzle/f3-data-warehouse/db.ts
+++ b/drizzle/f3-data-warehouse/db.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { loadEnvConfig } from '@/lib/env';
+import { WAREHOUSE_POOL_CONFIG } from '../pool-config';
 import * as schema from './schema';
 
 // Load environment variables
@@ -9,6 +10,7 @@ const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
 // Create PostgreSQL connection pool
 const pool = new Pool({
   connectionString: F3_DATA_WAREHOUSE_URL,
+  ...WAREHOUSE_POOL_CONFIG,
 });
 
 // Create drizzle database instance

--- a/drizzle/f3-data-warehouse/db.ts
+++ b/drizzle/f3-data-warehouse/db.ts
@@ -1,23 +1,128 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import type { IpAddressTypes } from '@google-cloud/cloud-sql-connector';
 import { loadEnvConfig } from '@/lib/env';
 import { WAREHOUSE_POOL_CONFIG } from '../pool-config';
 import { RetryPool } from '../retry-pool';
 import * as schema from './schema';
 
-// Load environment variables
-const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
+let pool: RetryPool | Pool | null = null;
+let connector: InstanceType<
+  typeof import('@google-cloud/cloud-sql-connector').Connector
+> | null = null;
+let dbInstance: NodePgDatabase<typeof schema> | null = null;
+let initPromise: Promise<NodePgDatabase<typeof schema>> | null = null;
 
-// Create PostgreSQL connection pool with automatic retry on transient errors
-const pool = new RetryPool({
-  connectionString: F3_DATA_WAREHOUSE_URL,
-  ...WAREHOUSE_POOL_CONFIG,
-  maxRetries: 3,
-  retryBaseDelayMs: 2_000,
-  retryMaxDelayMs: 15_000,
-});
+/**
+ * Creates a pool using the Cloud SQL Node.js Connector.
+ * Requires: CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, WAREHOUSE_DB_NAME
+ */
+async function createCloudSqlPool(): Promise<Pool> {
+  const { Connector, IpAddressTypes: IpAddressTypesValues } = await import(
+    '@google-cloud/cloud-sql-connector'
+  );
 
-// Create drizzle database instance
-export const db = drizzle(pool, { schema });
+  const instanceConnectionName =
+    process.env.CLOUD_SQL_WAREHOUSE_CONNECTION_NAME;
+  const dbUser = process.env.WAREHOUSE_DB_USER;
+  const dbPassword = process.env.WAREHOUSE_DB_PASSWORD;
+  const dbName = process.env.WAREHOUSE_DB_NAME;
 
-// Export for use in scripts and pre-flight checks
-export const getPool = () => pool;
+  if (!instanceConnectionName || !dbUser || !dbName) {
+    throw new Error(
+      'Cloud SQL Connector requires CLOUD_SQL_WAREHOUSE_CONNECTION_NAME, WAREHOUSE_DB_USER, and WAREHOUSE_DB_NAME.'
+    );
+  }
+
+  const validTypes = Object.values(IpAddressTypesValues) as string[];
+  const ipAddressType = validTypes.includes(
+    process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE ?? ''
+  )
+    ? (process.env.CLOUD_SQL_WAREHOUSE_IP_TYPE as IpAddressTypes)
+    : IpAddressTypesValues.PUBLIC;
+
+  connector = new Connector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName,
+    ipType: ipAddressType,
+  });
+
+  const newPool = new Pool({
+    ...clientOpts,
+    ...WAREHOUSE_POOL_CONFIG,
+    user: dbUser,
+    password: dbPassword,
+    database: dbName,
+  });
+
+  newPool.on('error', (err) => {
+    console.error('[warehouse] idle client error:', err.message);
+  });
+
+  console.log(
+    `[warehouse] pool initialized via Cloud SQL Connector (${instanceConnectionName})`
+  );
+  return newPool;
+}
+
+/**
+ * Creates a RetryPool using a direct TCP connection via F3_DATA_WAREHOUSE_URL.
+ * Includes automatic retry on transient errors (ETIMEDOUT, ECONNRESET, etc).
+ */
+function createDirectPool(): RetryPool {
+  const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
+
+  return new RetryPool({
+    connectionString: F3_DATA_WAREHOUSE_URL,
+    ...WAREHOUSE_POOL_CONFIG,
+    maxRetries: 3,
+    retryBaseDelayMs: 2_000,
+    retryMaxDelayMs: 15_000,
+  });
+}
+
+/**
+ * Returns a cached Drizzle database instance for the F3 Data Warehouse.
+ *
+ * Connection mode is controlled by WAREHOUSE_DB_CONNECTION_MODE:
+ *   "connector" -> Cloud SQL Node.js Connector (authenticated, no public IP needed)
+ *   "direct"    -> F3_DATA_WAREHOUSE_URL TCP connection with RetryPool (default)
+ */
+export async function getDb(): Promise<NodePgDatabase<typeof schema>> {
+  if (dbInstance) return dbInstance;
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    const mode = process.env.WAREHOUSE_DB_CONNECTION_MODE ?? 'direct';
+
+    if (mode === 'connector') {
+      pool = await createCloudSqlPool();
+    } else {
+      pool = createDirectPool();
+    }
+
+    dbInstance = drizzle(pool, { schema });
+    console.log(`[warehouse] connection mode: ${mode}`);
+    return dbInstance;
+  })();
+
+  return initPromise;
+}
+
+export async function getPool(): Promise<RetryPool | Pool> {
+  if (!pool) await getDb();
+  return pool!;
+}
+
+export async function close(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+  if (connector) {
+    connector.close();
+    connector = null;
+  }
+  dbInstance = null;
+  initPromise = null;
+}

--- a/drizzle/f3-data-warehouse/db.ts
+++ b/drizzle/f3-data-warehouse/db.ts
@@ -1,20 +1,23 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
 import { loadEnvConfig } from '@/lib/env';
 import { WAREHOUSE_POOL_CONFIG } from '../pool-config';
+import { RetryPool } from '../retry-pool';
 import * as schema from './schema';
 
 // Load environment variables
 const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
 
-// Create PostgreSQL connection pool
-const pool = new Pool({
+// Create PostgreSQL connection pool with automatic retry on transient errors
+const pool = new RetryPool({
   connectionString: F3_DATA_WAREHOUSE_URL,
   ...WAREHOUSE_POOL_CONFIG,
+  maxRetries: 3,
+  retryBaseDelayMs: 2_000,
+  retryMaxDelayMs: 15_000,
 });
 
 // Create drizzle database instance
 export const db = drizzle(pool, { schema });
 
-// Export for use in scripts
+// Export for use in scripts and pre-flight checks
 export const getPool = () => pool;

--- a/drizzle/pool-config.test.ts
+++ b/drizzle/pool-config.test.ts
@@ -3,12 +3,12 @@ import { WAREHOUSE_POOL_CONFIG, SUPABASE_POOL_CONFIG } from './pool-config';
 describe('Pool Configuration', () => {
   describe('warehouse pool', () => {
     it('should have a conservative max connection limit', () => {
-      expect(WAREHOUSE_POOL_CONFIG.max).toBeLessThanOrEqual(5);
+      expect(WAREHOUSE_POOL_CONFIG.max).toBeLessThanOrEqual(3);
     });
     it('should have explicit connection timeout', () => {
       expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeDefined();
       expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeLessThanOrEqual(
-        15_000
+        30_000
       );
     });
     it('should have explicit idle timeout', () => {

--- a/drizzle/pool-config.test.ts
+++ b/drizzle/pool-config.test.ts
@@ -1,0 +1,33 @@
+import { WAREHOUSE_POOL_CONFIG, SUPABASE_POOL_CONFIG } from './pool-config';
+
+describe('Pool Configuration', () => {
+  describe('warehouse pool', () => {
+    it('should have a conservative max connection limit', () => {
+      expect(WAREHOUSE_POOL_CONFIG.max).toBeLessThanOrEqual(5);
+    });
+    it('should have explicit connection timeout', () => {
+      expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeDefined();
+      expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeLessThanOrEqual(15_000);
+    });
+    it('should have explicit idle timeout', () => {
+      expect(WAREHOUSE_POOL_CONFIG.idleTimeoutMillis).toBeDefined();
+    });
+    it('should have statement timeout', () => {
+      expect(WAREHOUSE_POOL_CONFIG.statement_timeout).toBeDefined();
+    });
+  });
+
+  describe('supabase pool', () => {
+    it('should allow more connections than warehouse', () => {
+      expect(SUPABASE_POOL_CONFIG.max).toBeGreaterThan(WAREHOUSE_POOL_CONFIG.max);
+    });
+    it('should have explicit connection timeout', () => {
+      expect(SUPABASE_POOL_CONFIG.connectionTimeoutMillis).toBeDefined();
+    });
+    it('should have longer statement timeout for upserts', () => {
+      expect(SUPABASE_POOL_CONFIG.statement_timeout).toBeGreaterThanOrEqual(
+        WAREHOUSE_POOL_CONFIG.statement_timeout!
+      );
+    });
+  });
+});

--- a/drizzle/pool-config.test.ts
+++ b/drizzle/pool-config.test.ts
@@ -7,7 +7,9 @@ describe('Pool Configuration', () => {
     });
     it('should have explicit connection timeout', () => {
       expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeDefined();
-      expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeLessThanOrEqual(15_000);
+      expect(WAREHOUSE_POOL_CONFIG.connectionTimeoutMillis).toBeLessThanOrEqual(
+        15_000
+      );
     });
     it('should have explicit idle timeout', () => {
       expect(WAREHOUSE_POOL_CONFIG.idleTimeoutMillis).toBeDefined();
@@ -19,7 +21,9 @@ describe('Pool Configuration', () => {
 
   describe('supabase pool', () => {
     it('should allow more connections than warehouse', () => {
-      expect(SUPABASE_POOL_CONFIG.max).toBeGreaterThan(WAREHOUSE_POOL_CONFIG.max);
+      expect(SUPABASE_POOL_CONFIG.max).toBeGreaterThan(
+        WAREHOUSE_POOL_CONFIG.max
+      );
     });
     it('should have explicit connection timeout', () => {
       expect(SUPABASE_POOL_CONFIG.connectionTimeoutMillis).toBeDefined();

--- a/drizzle/pool-config.ts
+++ b/drizzle/pool-config.ts
@@ -1,8 +1,8 @@
 export const WAREHOUSE_POOL_CONFIG = {
-  max: 5,
-  idleTimeoutMillis: 10_000,
-  connectionTimeoutMillis: 10_000,
-  statement_timeout: 30_000,
+  max: 3,
+  idleTimeoutMillis: 30_000,
+  connectionTimeoutMillis: 30_000,
+  statement_timeout: 60_000,
 };
 
 export const SUPABASE_POOL_CONFIG = {

--- a/drizzle/pool-config.ts
+++ b/drizzle/pool-config.ts
@@ -1,0 +1,13 @@
+export const WAREHOUSE_POOL_CONFIG = {
+  max: 5,
+  idleTimeoutMillis: 10_000,
+  connectionTimeoutMillis: 10_000,
+  statement_timeout: 30_000,
+};
+
+export const SUPABASE_POOL_CONFIG = {
+  max: 10,
+  idleTimeoutMillis: 10_000,
+  connectionTimeoutMillis: 10_000,
+  statement_timeout: 60_000,
+};

--- a/drizzle/retry-pool.test.ts
+++ b/drizzle/retry-pool.test.ts
@@ -1,0 +1,122 @@
+import { RetryPool } from './retry-pool';
+
+// Mock pg.Pool — we test the retry logic, not actual TCP connections
+jest.mock('pg', () => {
+  const original = jest.requireActual('pg');
+  return {
+    ...original,
+    Pool: class MockPool {
+      private connectFn: (() => Promise<unknown>) | undefined;
+      on() {
+        return this;
+      }
+      // Overridden by RetryPool, but needed for super.connect()
+      async connect() {
+        if (this.connectFn) return this.connectFn();
+        return { query: jest.fn(), release: jest.fn() };
+      }
+      _setConnectFn(fn: () => Promise<unknown>) {
+        this.connectFn = fn;
+      }
+    },
+  };
+});
+
+describe('RetryPool', () => {
+  it('should succeed on first attempt when connection works', async () => {
+    const pool = new RetryPool({
+      connectionString: 'postgresql://test',
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+    });
+
+    const client = await pool.connect();
+    expect(client).toBeDefined();
+  });
+
+  it('should retry on ETIMEDOUT and succeed on later attempt', async () => {
+    let attempt = 0;
+    const pool = new RetryPool({
+      connectionString: 'postgresql://test',
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+    });
+
+    // Monkey-patch the parent connect to simulate failures
+    const origConnect = Object.getPrototypeOf(
+      Object.getPrototypeOf(pool)
+    ).connect;
+    const mockClient = { query: jest.fn(), release: jest.fn() };
+
+    jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(pool)), 'connect')
+      .mockImplementation(async () => {
+        attempt++;
+        if (attempt < 3) {
+          throw new Error('connect ETIMEDOUT 35.239.19.124:5432');
+        }
+        return mockClient;
+      });
+
+    const client = await pool.connect();
+    expect(attempt).toBe(3);
+    expect(client).toBe(mockClient);
+  });
+
+  it('should throw after exhausting all retries', async () => {
+    const pool = new RetryPool({
+      connectionString: 'postgresql://test',
+      maxRetries: 2,
+      retryBaseDelayMs: 10,
+    });
+
+    jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(pool)), 'connect')
+      .mockRejectedValue(new Error('connect ETIMEDOUT 35.239.19.124:5432'));
+
+    await expect(pool.connect()).rejects.toThrow('ETIMEDOUT');
+  });
+
+  it('should not retry on non-transient errors', async () => {
+    let attempts = 0;
+    const pool = new RetryPool({
+      connectionString: 'postgresql://test',
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+    });
+
+    jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(pool)), 'connect')
+      .mockImplementation(async () => {
+        attempts++;
+        throw new Error('password authentication failed');
+      });
+
+    await expect(pool.connect()).rejects.toThrow('password authentication');
+    expect(attempts).toBe(1);
+  });
+
+  it('should retry on ECONNRESET errors', async () => {
+    let attempts = 0;
+    const pool = new RetryPool({
+      connectionString: 'postgresql://test',
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+    });
+
+    const mockClient = { query: jest.fn(), release: jest.fn() };
+    jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(pool)), 'connect')
+      .mockImplementation(async () => {
+        attempts++;
+        if (attempts < 2) {
+          throw new Error('read ECONNRESET');
+        }
+        return mockClient;
+      });
+
+    const client = await pool.connect();
+    expect(attempts).toBe(2);
+    expect(client).toBe(mockClient);
+  });
+});

--- a/drizzle/retry-pool.ts
+++ b/drizzle/retry-pool.ts
@@ -1,0 +1,97 @@
+import { Pool, PoolClient, PoolConfig } from 'pg';
+
+export type RetryPoolConfig = PoolConfig & {
+  /** Max connection attempts before giving up. Default: 3 */
+  maxRetries?: number;
+  /** Base delay in ms between retries (doubles each attempt). Default: 2000 */
+  retryBaseDelayMs?: number;
+  /** Max delay cap in ms. Default: 15000 */
+  retryMaxDelayMs?: number;
+};
+
+const RETRYABLE_PATTERNS = [
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'connection terminated',
+  'Connection terminated',
+];
+
+function isRetryable(error: unknown): boolean {
+  const message = String(error);
+  return RETRYABLE_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+function backoffDelay(attempt: number, baseMs: number, maxMs: number): number {
+  return Math.min(baseMs * Math.pow(2, attempt - 1), maxMs);
+}
+
+/**
+ * A pg Pool subclass that retries connection acquisition on transient
+ * network errors (ETIMEDOUT, ECONNRESET, ECONNREFUSED).
+ *
+ * Drizzle and raw pool.query() both go through connect() internally,
+ * so all queries through this pool get automatic retry behaviour.
+ */
+export class RetryPool extends Pool {
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
+  private readonly retryMaxDelayMs: number;
+
+  constructor(config: RetryPoolConfig) {
+    const { maxRetries, retryBaseDelayMs, retryMaxDelayMs, ...poolConfig } =
+      config;
+    super(poolConfig);
+    this.maxRetries = maxRetries ?? 3;
+    this.retryBaseDelayMs = retryBaseDelayMs ?? 2_000;
+    this.retryMaxDelayMs = retryMaxDelayMs ?? 15_000;
+
+    // Log pool-level errors instead of crashing
+    this.on('error', (err) => {
+      console.error('[RetryPool] idle client error:', err.message);
+    });
+  }
+
+  override async connect(): Promise<PoolClient> {
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      try {
+        return await super.connect();
+      } catch (error) {
+        if (!isRetryable(error) || attempt >= this.maxRetries) {
+          throw error;
+        }
+
+        const delay = backoffDelay(
+          attempt,
+          this.retryBaseDelayMs,
+          this.retryMaxDelayMs
+        );
+        console.warn(
+          `[RetryPool] connect failed (attempt ${attempt}/${this.maxRetries}): ${String(error)}. Retrying in ${delay}ms...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    // Unreachable — the loop always throws on final attempt
+    throw new Error('[RetryPool] connect exhausted retries');
+  }
+
+  /**
+   * Quick connectivity check — runs SELECT 1 and returns true/false.
+   * Useful as a pre-flight check before long-running pipelines.
+   */
+  async isReachable(): Promise<boolean> {
+    try {
+      const client = await this.connect();
+      try {
+        await client.query('SELECT 1');
+        return true;
+      } finally {
+        client.release();
+      }
+    } catch {
+      return false;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postinstall": "pnpm skills:check"
   },
   "dependencies": {
+    "@google-cloud/cloud-sql-connector": "^1.9.2",
     "dotenv": "^16.4.7",
     "lodash": "^4.17.21",
     "next": "15.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google-cloud/cloud-sql-connector':
+        specifier: ^1.9.2
+        version: 1.9.2
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -842,8 +845,8 @@ packages:
   '@firebase/webchannel-wrapper@1.0.5':
     resolution: {integrity: sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==}
 
-  '@google-cloud/cloud-sql-connector@1.8.4':
-    resolution: {integrity: sha512-dX36ksbh4xrIsALCHxNYXwvRUtlZ/msQ/PL0LpSYWHnfMenRM+watAzM/XIVr8tQOtzhT7mrmrAb/W/bgayQAQ==}
+  '@google-cloud/cloud-sql-connector@1.9.2':
+    resolution: {integrity: sha512-o2LYUAKHvNtgevMCOaMH7bCDnRcyC9Z8UtEG6aPwjN+yIld1I6QPu+6Iq4n+/CHC7P4o+UlsNpHa9Hf/oM81qQ==}
     engines: {node: '>=18'}
 
   '@google-cloud/paginator@6.0.0':
@@ -866,8 +869,8 @@ packages:
     resolution: {integrity: sha512-YNSRBo85mgPQ9QuuzAHjmLwngIwmy2RjAUAoPl2mOL2+bCM0cAVZswPb8ylcsWJP7PgDJlck+ybv0MwJ9AM0sg==}
     engines: {node: '>=18'}
 
-  '@googleapis/sqladmin@31.1.0':
-    resolution: {integrity: sha512-k4lXSFCFuZmWtYuW/OH/PcHimZP5P/uDLK0+ACbgoZFB8qmlgcyF0531aJt6JHIdBwCRlHXZlMW4LDC5Gqra5w==}
+  '@googleapis/sqladmin@35.2.0':
+    resolution: {integrity: sha512-ajR9EGLs1pCkKfsXxfbVRnQ7ZPyktKNAuahHoU06CVKguWwQo3b9aFmq06PYnGk1oXc0+tlW+XEamNa/HF4pbQ==}
     engines: {node: '>=12.0.0'}
 
   '@grpc/grpc-js@1.14.2':
@@ -3087,6 +3090,10 @@ packages:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
     engines: {node: '>=18'}
 
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
@@ -3177,6 +3184,10 @@ packages:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
@@ -3193,8 +3204,8 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
-  googleapis-common@8.0.2-rc.0:
-    resolution: {integrity: sha512-JTcxRvmFa9Ec1uyfMEimEMeeKq1sHNZX3vn2qmoUMtnvixXXvcqTcbDZvEZXkEWpGlPlOf4joyep6/qs0BrLyg==}
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
     engines: {node: '>=18.0.0'}
 
   gopd@1.2.0:
@@ -6377,11 +6388,11 @@ snapshots:
 
   '@firebase/webchannel-wrapper@1.0.5': {}
 
-  '@google-cloud/cloud-sql-connector@1.8.4':
+  '@google-cloud/cloud-sql-connector@1.9.2':
     dependencies:
-      '@googleapis/sqladmin': 31.1.0
-      gaxios: 7.1.3
-      google-auth-library: 10.5.0
+      '@googleapis/sqladmin': 35.2.0
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
       p-throttle: 7.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6416,9 +6427,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@googleapis/sqladmin@31.1.0':
+  '@googleapis/sqladmin@35.2.0':
     dependencies:
-      googleapis-common: 8.0.2-rc.0
+      googleapis-common: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8843,7 +8854,7 @@ snapshots:
       '@apphosting/common': 0.0.8
       '@electric-sql/pglite': 0.3.14
       '@electric-sql/pglite-tools': 0.2.19(@electric-sql/pglite@0.3.14)
-      '@google-cloud/cloud-sql-connector': 1.8.4
+      '@google-cloud/cloud-sql-connector': 1.9.2
       '@google-cloud/pubsub': 5.2.0
       '@inquirer/prompts': 7.10.1(@types/node@20.19.24)
       '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
@@ -9053,6 +9064,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
       gaxios: 6.7.1(encoding@0.1.13)
@@ -9064,7 +9083,7 @@ snapshots:
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.3
+      gaxios: 7.1.4
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -9184,6 +9203,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
       base64-js: 1.5.1
@@ -9216,11 +9246,11 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@8.0.2-rc.0:
+  googleapis-common@8.0.1:
     dependencies:
       extend: 3.0.2
-      gaxios: 7.1.3
-      google-auth-library: 10.5.0
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
       qs: 6.14.0
       url-template: 2.0.8
     transitivePeerDependencies:

--- a/scripts/generate-warehouse-schema.ts
+++ b/scripts/generate-warehouse-schema.ts
@@ -8,6 +8,12 @@ async function generateWarehouseSchema() {
     // Load environment variables
     const { F3_DATA_WAREHOUSE_URL } = loadEnvConfig();
 
+    if (!F3_DATA_WAREHOUSE_URL) {
+      throw new Error(
+        'F3_DATA_WAREHOUSE_URL is required for schema generation (set WAREHOUSE_DB_CONNECTION_MODE=direct)'
+      );
+    }
+
     console.log('🔍 Generating schema from F3 Data Warehouse...');
     console.log(
       `📊 Database URL: ${F3_DATA_WAREHOUSE_URL.replace(/:[^:@]*@/, ':***@')}`

--- a/scripts/prune-regions.ts
+++ b/scripts/prune-regions.ts
@@ -5,12 +5,13 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { orgs as orgsSchema } from '../drizzle/f3-data-warehouse/schema';
 
 export async function pruneRegions() {
   console.debug('🔄 pruning regions no longer in the warehouse...');
 
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const activeWarehouseRegions = await f3DataWarehouseDb
     .select({
       id: orgsSchema.id,

--- a/scripts/prune-workouts.ts
+++ b/scripts/prune-workouts.ts
@@ -24,7 +24,7 @@ export async function pruneWorkouts() {
       and(
         eq(eventsSchema.isActive, true),
         eq(orgsSchema.isActive, true),
-        eq(orgsSchema.orgType, 'ao'),
+        eq(orgsSchema.orgType, 'ao')
       )
     );
   const activeWorkoutIds = new Set(

--- a/scripts/prune-workouts.ts
+++ b/scripts/prune-workouts.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import { db } from '../drizzle/db';
 import {
@@ -6,7 +6,10 @@ import {
   workouts as workoutsSchema,
 } from '../drizzle/schema';
 import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
-import { events as eventsSchema } from '../drizzle/f3-data-warehouse/schema';
+import {
+  events as eventsSchema,
+  orgs as orgsSchema,
+} from '../drizzle/f3-data-warehouse/schema';
 
 export async function pruneWorkouts() {
   console.debug('🔄 pruning workouts no longer in the warehouse...');
@@ -16,7 +19,14 @@ export async function pruneWorkouts() {
       id: eventsSchema.id,
     })
     .from(eventsSchema)
-    .where(eq(eventsSchema.isActive, true));
+    .innerJoin(orgsSchema, eq(eventsSchema.orgId, orgsSchema.id))
+    .where(
+      and(
+        eq(eventsSchema.isActive, true),
+        eq(orgsSchema.isActive, true),
+        eq(orgsSchema.orgType, 'ao'),
+      )
+    );
   const activeWorkoutIds = new Set(
     activeWarehouseWorkouts.map((workout) => workout.id.toString())
   );

--- a/scripts/prune-workouts.ts
+++ b/scripts/prune-workouts.ts
@@ -5,7 +5,7 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import {
   events as eventsSchema,
   orgs as orgsSchema,
@@ -14,6 +14,7 @@ import {
 export async function pruneWorkouts() {
   console.debug('🔄 pruning workouts no longer in the warehouse...');
 
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const activeWarehouseWorkouts = await f3DataWarehouseDb
     .select({
       id: eventsSchema.id,

--- a/scripts/seed-regions.ts
+++ b/scripts/seed-regions.ts
@@ -3,7 +3,7 @@ import { kebabCase } from 'lodash';
 
 import { db } from '../drizzle/db';
 import { regions as regionsSchema } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import { orgs as orgsSchema } from '../drizzle/f3-data-warehouse/schema';
 import { currentIngestedAt, isFresh } from './seed-state';
 
@@ -149,6 +149,7 @@ function transformInstagramUrl(instagram: string | null): string | null {
 }
 
 async function* fetchRegions(): AsyncGenerator<Region> {
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const regions = await f3DataWarehouseDb
     .select({
       id: orgsSchema.id,

--- a/scripts/seed-workouts.test.ts
+++ b/scripts/seed-workouts.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('seed-workouts configuration', () => {
+  const source = readFileSync(join(__dirname, 'seed-workouts.ts'), 'utf-8');
+
+  it('should default UPSERT_CONCURRENCY to 4', () => {
+    expect(source).toContain("?? '4'");
+    expect(source).not.toContain("?? '8'");
+  });
+});

--- a/scripts/seed-workouts.test.ts
+++ b/scripts/seed-workouts.test.ts
@@ -4,8 +4,8 @@ import { join } from 'path';
 describe('seed-workouts configuration', () => {
   const source = readFileSync(join(__dirname, 'seed-workouts.ts'), 'utf-8');
 
-  it('should default UPSERT_CONCURRENCY to 4', () => {
-    expect(source).toContain("?? '4'");
+  it('should default UPSERT_CONCURRENCY to 2', () => {
+    expect(source).toContain("?? '2'");
     expect(source).not.toContain("?? '8'");
   });
 });

--- a/scripts/seed-workouts.ts
+++ b/scripts/seed-workouts.ts
@@ -5,7 +5,7 @@ import {
   regions as regionsSchema,
   workouts as workoutsSchema,
 } from '../drizzle/schema';
-import { db as f3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
+import { getDb as getF3DataWarehouseDb } from '../drizzle/f3-data-warehouse/db';
 import {
   orgs as orgsSchema,
   events as eventsSchema,
@@ -294,6 +294,7 @@ type FetchBatchArgs = {
 };
 
 async function fetchWorkoutsBatch(args: FetchBatchArgs): Promise<BatchResult> {
+  const f3DataWarehouseDb = await getF3DataWarehouseDb();
   const conditions = [eq(eventsSchema.isActive, true)];
   if (args.updatedAfter) {
     conditions.push(gte(eventsSchema.updated, args.updatedAfter));

--- a/scripts/seed-workouts.ts
+++ b/scripts/seed-workouts.ts
@@ -40,16 +40,14 @@ type SeedOptions = {
   updatedAfter?: string;
 };
 
-const DEFAULT_BATCH_SIZE = Number(
-  process.env.WORKOUT_SEED_BATCH_SIZE ?? '1000'
-);
+const DEFAULT_BATCH_SIZE = Number(process.env.WORKOUT_SEED_BATCH_SIZE ?? '500');
 const DEFAULT_MAX_BATCHES = process.env.WORKOUT_SEED_MAX_BATCHES
   ? Number(process.env.WORKOUT_SEED_MAX_BATCHES)
   : undefined;
 const DEFAULT_UPDATED_AFTER = process.env.WORKOUT_SEED_UPDATED_AFTER;
 const UPSERT_CONCURRENCY = Math.max(
   1,
-  Number(process.env.WORKOUT_SEED_UPSERT_CONCURRENCY ?? '4')
+  Number(process.env.WORKOUT_SEED_UPSERT_CONCURRENCY ?? '2')
 );
 
 async function loadWorkoutIngestionMap() {

--- a/scripts/seed-workouts.ts
+++ b/scripts/seed-workouts.ts
@@ -49,7 +49,7 @@ const DEFAULT_MAX_BATCHES = process.env.WORKOUT_SEED_MAX_BATCHES
 const DEFAULT_UPDATED_AFTER = process.env.WORKOUT_SEED_UPDATED_AFTER;
 const UPSERT_CONCURRENCY = Math.max(
   1,
-  Number(process.env.WORKOUT_SEED_UPSERT_CONCURRENCY ?? '8')
+  Number(process.env.WORKOUT_SEED_UPSERT_CONCURRENCY ?? '4')
 );
 
 async function loadWorkoutIngestionMap() {

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { eq } from 'drizzle-orm';
 
 import { db } from '../../../../drizzle/db';
+import { getPool as getWarehousePool } from '../../../../drizzle/f3-data-warehouse/db';
 import { seedRuns, ingestRuns } from '../../../../drizzle/schema';
 import { pruneRegions } from '../../../../scripts/prune-regions';
 import { pruneWorkouts } from '../../../../scripts/prune-workouts';
@@ -107,7 +108,39 @@ export async function POST(request: NextRequest) {
       .values({ startedAt, status: 'running' })
       .returning({ id: ingestRuns.id });
 
-    // 4. Run ingest
+    // 4. Pre-flight: verify warehouse connectivity before running the pipeline
+    const warehousePool = getWarehousePool();
+    const warehouseReachable = await warehousePool.isReachable();
+    if (!warehouseReachable) {
+      const msg =
+        'Warehouse database is unreachable after retry attempts — aborting ingest';
+      console.error(msg);
+
+      try {
+        await db
+          .update(ingestRuns)
+          .set({
+            completedAt: new Date().toISOString(),
+            status: 'failure',
+            durationSec: 0,
+            errorMessage: msg,
+          })
+          .where(eq(ingestRuns.id, runRow.id));
+      } catch (persistError) {
+        console.error('Failed to persist pre-flight failure:', persistError);
+      }
+
+      await sendSlackNotification(
+        `:x: F3 Region Pages daily ingest failed: ${escapeSlack(msg)}`
+      );
+      return NextResponse.json(
+        { status: 'error', message: msg },
+        { status: 503 }
+      );
+    }
+    console.log('✅ Warehouse pre-flight check passed');
+
+    // 5. Run ingest
     try {
       const startTime = Date.now();
 
@@ -119,7 +152,7 @@ export async function POST(request: NextRequest) {
 
       const durationSec = Math.round((Date.now() - startTime) / 1000);
 
-      // 5. Record successful run in seedRuns
+      // 6. Record successful run in seedRuns
       const now = new Date().toISOString();
       await db
         .insert(seedRuns)
@@ -129,7 +162,7 @@ export async function POST(request: NextRequest) {
           set: { lastIngestedAt: now },
         });
 
-      // 6. Build stats
+      // 7. Build stats
       const stats = {
         durationSec,
         regionsPruned: pruneRegionsStats.removed,
@@ -148,7 +181,7 @@ export async function POST(request: NextRequest) {
         regionsEnriched: enrichRegionsStats.enriched,
       };
 
-      // 7. Get comparison analytics (before persisting success so current run isn't in the window)
+      // 8. Get comparison analytics (before persisting success so current run isn't in the window)
       const comparison = await getIngestComparison({
         workoutsSeeded: stats.workoutsSeeded,
         workoutsSkipped: stats.workoutsSkipped,
@@ -156,7 +189,7 @@ export async function POST(request: NextRequest) {
         durationSec: stats.durationSec,
       });
 
-      // 8. Persist full stats to ingestRuns
+      // 9. Persist full stats to ingestRuns
       await db
         .update(ingestRuns)
         .set({
@@ -182,7 +215,7 @@ export async function POST(request: NextRequest) {
         })
         .where(eq(ingestRuns.id, runRow.id));
 
-      // 9. Build Slack message
+      // 10. Build Slack message
       const fmt = (n: number) => n.toLocaleString('en-US');
 
       const capList = (

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -70,283 +70,306 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // 2. Check if already run today (idempotent, unless ?force=true)
-  const force = request.nextUrl.searchParams.get('force') === 'true';
-  const [lastRun] = await db
-    .select()
-    .from(seedRuns)
-    .where(eq(seedRuns.key, INGEST_KEY));
-
-  if (!force && lastRun?.lastIngestedAt) {
-    const elapsed = Date.now() - Date.parse(lastRun.lastIngestedAt);
-    if (elapsed < FRESH_WINDOW_MS) {
-      // Persist skipped run
-      await db.insert(ingestRuns).values({
-        startedAt: new Date().toISOString(),
-        completedAt: new Date().toISOString(),
-        status: 'skipped',
-        durationSec: 0,
-      });
-
-      await sendSlackNotification(
-        `:hourglass_flowing_sand: F3 Region Pages daily ingest skipped (already ran at ${lastRun.lastIngestedAt})`
-      );
-      return NextResponse.json({
-        status: 'skipped',
-        message: 'Already ingested today',
-        lastIngestedAt: lastRun.lastIngestedAt,
-      });
-    }
-  }
-
-  // 3. Persist running state
-  const startedAt = new Date().toISOString();
-  const [runRow] = await db
-    .insert(ingestRuns)
-    .values({ startedAt, status: 'running' })
-    .returning({ id: ingestRuns.id });
-
-  // 4. Run ingest
   try {
-    const startTime = Date.now();
+    // 2. Check if already run today (idempotent, unless ?force=true)
+    const force = request.nextUrl.searchParams.get('force') === 'true';
+    const [lastRun] = await db
+      .select()
+      .from(seedRuns)
+      .where(eq(seedRuns.key, INGEST_KEY));
 
-    const pruneRegionsStats = await pruneRegions();
-    const pruneWorkoutsStats = await pruneWorkouts();
-    const seedRegionsStats = await seedRegions();
-    const seedWorkoutsStats = await seedWorkouts();
-    const enrichRegionsStats = await enrichRegions();
+    if (!force && lastRun?.lastIngestedAt) {
+      const elapsed = Date.now() - Date.parse(lastRun.lastIngestedAt);
+      if (elapsed < FRESH_WINDOW_MS) {
+        // Persist skipped run
+        await db.insert(ingestRuns).values({
+          startedAt: new Date().toISOString(),
+          completedAt: new Date().toISOString(),
+          status: 'skipped',
+          durationSec: 0,
+        });
 
-    const durationSec = Math.round((Date.now() - startTime) / 1000);
+        await sendSlackNotification(
+          `:hourglass_flowing_sand: F3 Region Pages daily ingest skipped (already ran at ${lastRun.lastIngestedAt})`
+        );
+        return NextResponse.json({
+          status: 'skipped',
+          message: 'Already ingested today',
+          lastIngestedAt: lastRun.lastIngestedAt,
+        });
+      }
+    }
 
-    // 5. Record successful run in seedRuns
-    const now = new Date().toISOString();
-    await db
-      .insert(seedRuns)
-      .values({ key: INGEST_KEY, lastIngestedAt: now })
-      .onConflictDoUpdate({
-        target: seedRuns.key,
-        set: { lastIngestedAt: now },
-      });
+    // 3. Persist running state
+    const startedAt = new Date().toISOString();
+    const [runRow] = await db
+      .insert(ingestRuns)
+      .values({ startedAt, status: 'running' })
+      .returning({ id: ingestRuns.id });
 
-    // 6. Build stats
-    const stats = {
-      durationSec,
-      regionsPruned: pruneRegionsStats.removed,
-      regionsPrunedNames: pruneRegionsStats.regionNames,
-      workoutsPruned: pruneWorkoutsStats.removed,
-      workoutsPrunedItems: pruneWorkoutsStats.workouts,
-      regionsSeeded: seedRegionsStats.upserted,
-      regionsSkippedFresh: seedRegionsStats.skippedFresh,
-      regionsSeededNames: seedRegionsStats.regionNames,
-      workoutsSeeded: seedWorkoutsStats.upserted,
-      workoutsDeduplicated: seedWorkoutsStats.deduplicated,
-      workoutsSkipped: seedWorkoutsStats.skipped,
-      workoutBatches: seedWorkoutsStats.batches,
-      workoutRegionBreakdown: seedWorkoutsStats.regionBreakdown,
-      skipBreakdown: seedWorkoutsStats.skipBreakdown,
-      regionsEnriched: enrichRegionsStats.enriched,
-    };
+    // 4. Run ingest
+    try {
+      const startTime = Date.now();
 
-    // 7. Get comparison analytics (before persisting success so current run isn't in the window)
-    const comparison = await getIngestComparison({
-      workoutsSeeded: stats.workoutsSeeded,
-      workoutsSkipped: stats.workoutsSkipped,
-      regionsSeeded: stats.regionsSeeded,
-      durationSec: stats.durationSec,
-    });
+      const pruneRegionsStats = await pruneRegions();
+      const pruneWorkoutsStats = await pruneWorkouts();
+      const seedRegionsStats = await seedRegions();
+      const seedWorkoutsStats = await seedWorkouts();
+      const enrichRegionsStats = await enrichRegions();
 
-    // 8. Persist full stats to ingestRuns
-    await db
-      .update(ingestRuns)
-      .set({
-        completedAt: now,
-        status: 'success',
-        durationSec: stats.durationSec,
-        regionsPruned: stats.regionsPruned,
-        workoutsPruned: stats.workoutsPruned,
-        regionsSeeded: stats.regionsSeeded,
-        regionsSkippedFresh: stats.regionsSkippedFresh,
+      const durationSec = Math.round((Date.now() - startTime) / 1000);
+
+      // 5. Record successful run in seedRuns
+      const now = new Date().toISOString();
+      await db
+        .insert(seedRuns)
+        .values({ key: INGEST_KEY, lastIngestedAt: now })
+        .onConflictDoUpdate({
+          target: seedRuns.key,
+          set: { lastIngestedAt: now },
+        });
+
+      // 6. Build stats
+      const stats = {
+        durationSec,
+        regionsPruned: pruneRegionsStats.removed,
+        regionsPrunedNames: pruneRegionsStats.regionNames,
+        workoutsPruned: pruneWorkoutsStats.removed,
+        workoutsPrunedItems: pruneWorkoutsStats.workouts,
+        regionsSeeded: seedRegionsStats.upserted,
+        regionsSkippedFresh: seedRegionsStats.skippedFresh,
+        regionsSeededNames: seedRegionsStats.regionNames,
+        workoutsSeeded: seedWorkoutsStats.upserted,
+        workoutsDeduplicated: seedWorkoutsStats.deduplicated,
+        workoutsSkipped: seedWorkoutsStats.skipped,
+        workoutBatches: seedWorkoutsStats.batches,
+        workoutRegionBreakdown: seedWorkoutsStats.regionBreakdown,
+        skipBreakdown: seedWorkoutsStats.skipBreakdown,
+        regionsEnriched: enrichRegionsStats.enriched,
+      };
+
+      // 7. Get comparison analytics (before persisting success so current run isn't in the window)
+      const comparison = await getIngestComparison({
         workoutsSeeded: stats.workoutsSeeded,
         workoutsDeduplicated: stats.workoutsDeduplicated,
         workoutsSkipped: stats.workoutsSkipped,
-        workoutBatches: stats.workoutBatches,
-        workoutsSkippedFresh: stats.skipBreakdown.fresh,
-        workoutsSkippedMissingType: stats.skipBreakdown.missingType,
-        workoutsSkippedMissingAo: stats.skipBreakdown.missingAo,
-        workoutsSkippedMissingRegion: stats.skipBreakdown.missingRegion,
-        workoutsSkippedMissingLocation: stats.skipBreakdown.missingLocation,
-        workoutsSkippedMissingGroup: stats.skipBreakdown.missingGroup,
-        regionsEnriched: stats.regionsEnriched,
-        workoutRegionBreakdown: JSON.stringify(stats.workoutRegionBreakdown),
-      })
-      .where(eq(ingestRuns.id, runRow.id));
+        regionsSeeded: stats.regionsSeeded,
+        durationSec: stats.durationSec,
+      });
 
-    // 9. Build Slack message
-    const fmt = (n: number) => n.toLocaleString('en-US');
-
-    const capList = (items: { text: string; slug: string }[], max: number) => {
-      const formatted = items.map((item) => slackLink(item.slug, item.text));
-      return formatted.length <= max
-        ? formatted.join(', ')
-        : `${formatted.slice(0, max).join(', ')} _and ${items.length - max} more_`;
-    };
-
-    const formatBreakdown = (
-      breakdown: Record<string, number>,
-      max: number
-    ) => {
-      const entries = Object.entries(breakdown).sort(([, a], [, b]) => b - a);
-      const shown = entries.slice(0, max);
-      const lines = shown.map(
-        ([name, count]) =>
-          `  • ${slackLink(kebabCase(name), name)}: ${fmt(count)}`
-      );
-      if (entries.length > max) {
-        lines.push(`  • _and ${entries.length - max} more regions_`);
-      }
-      return lines.join('\n');
-    };
-
-    const regionsPrunedLine =
-      stats.regionsPruned > 0
-        ? `*Regions pruned (${fmt(stats.regionsPruned)}):* ${capList(
-            stats.regionsPrunedNames.map((n) => ({
-              text: n,
-              slug: kebabCase(n),
-            })),
-            10
-          )}`
-        : `*Regions pruned:* 0`;
-
-    const workoutsPrunedLine =
-      stats.workoutsPruned > 0
-        ? `*Workouts pruned (${fmt(stats.workoutsPruned)}):* ${capList(
-            stats.workoutsPrunedItems.map((w) => ({
-              text: w.name,
-              slug: kebabCase(w.regionName),
-            })),
-            10
-          )}`
-        : `*Workouts pruned:* 0`;
-
-    const regionsSeededLine =
-      stats.regionsSeeded > 0
-        ? `*Regions seeded (${fmt(stats.regionsSeeded)}):* ${capList(
-            stats.regionsSeededNames.map((n) => ({
-              text: n,
-              slug: kebabCase(n),
-            })),
-            10
-          )}` +
-          (stats.regionsSkippedFresh > 0
-            ? ` (${fmt(stats.regionsSkippedFresh)} skipped fresh)`
-            : '')
-        : `*Regions seeded:* 0` +
-          (stats.regionsSkippedFresh > 0
-            ? ` (${fmt(stats.regionsSkippedFresh)} skipped fresh)`
-            : '');
-
-    const workoutsSeededLine =
-      `*Workouts seeded (${fmt(stats.workoutsSeeded)}):* ${fmt(stats.workoutsSeeded)} in ${fmt(stats.workoutBatches)} batch(es)` +
-      (stats.workoutsDeduplicated > 0
-        ? ` (${fmt(stats.workoutsDeduplicated)} deduplicated)`
-        : '') +
-      (stats.workoutsSkipped > 0
-        ? ` (${fmt(stats.workoutsSkipped)} skipped)`
-        : '');
-
-    const breakdownSection =
-      Object.keys(stats.workoutRegionBreakdown).length > 0
-        ? '\n' + formatBreakdown(stats.workoutRegionBreakdown, 15)
-        : '';
-
-    // Skip breakdown line
-    const sb = stats.skipBreakdown;
-    const skipBreakdownLine =
-      stats.workoutsSkipped > 0
-        ? `*Skip breakdown:* fresh=${fmt(sb.fresh)}, missingType=${fmt(sb.missingType)}, missingAo=${fmt(sb.missingAo)}, missingRegion=${fmt(sb.missingRegion)}, missingLocation=${fmt(sb.missingLocation)}, missingGroup=${fmt(sb.missingGroup)}`
-        : '';
-
-    // Comparison lines
-    const comparisonLines: string[] = [];
-    if (comparison.deltas) {
-      const d = comparison.deltas;
-      const sign = d.workoutsSeeded >= 0 ? '+' : '';
-      const pctStr =
-        d.workoutsSeededPct !== 0
-          ? ` (${sign}${d.workoutsSeededPct.toFixed(0)}%)`
-          : '';
-      comparisonLines.push(
-        `*vs last run:* workouts ${sign}${fmt(d.workoutsSeeded)}${pctStr}, skip rate ${(comparison.skipRate * 100).toFixed(1)}%`
-      );
-    }
-    if (comparison.rolling.sampleSize >= 2) {
-      comparisonLines.push(
-        `*${comparison.rolling.sampleSize}-run avg:* ${fmt(Math.round(comparison.rolling.mean))} seeded (stddev ${fmt(Math.round(comparison.rolling.stddev))})`
-      );
-    }
-    if (comparison.anomaly.flagged) {
-      comparisonLines.push(
-        `:warning: *ANOMALY:* ${comparison.anomaly.message}`
-      );
-    }
-
-    const comparisonSection =
-      comparisonLines.length > 0 ? '\n' + comparisonLines.join('\n') : '';
-
-    await sendSlackNotification(
-      `:white_check_mark: F3 Region Pages daily ingest completed\n\n` +
-        `*Duration:* ${durationSec}s\n` +
-        `${regionsPrunedLine}\n` +
-        `${workoutsPrunedLine}\n` +
-        `${regionsSeededLine}\n` +
-        `${workoutsSeededLine}${breakdownSection}\n` +
-        (skipBreakdownLine ? `${skipBreakdownLine}\n` : '') +
-        `*Regions enriched:* ${fmt(stats.regionsEnriched)}` +
-        comparisonSection
-    );
-
-    const {
-      regionsPrunedNames: _rpn, // eslint-disable-line @typescript-eslint/no-unused-vars
-      workoutsPrunedItems: _wpi, // eslint-disable-line @typescript-eslint/no-unused-vars
-      regionsSeededNames: _rsn, // eslint-disable-line @typescript-eslint/no-unused-vars
-      workoutRegionBreakdown: _wrb, // eslint-disable-line @typescript-eslint/no-unused-vars
-      skipBreakdown: _sb, // eslint-disable-line @typescript-eslint/no-unused-vars
-      ...summaryStats
-    } = stats;
-
-    return NextResponse.json({
-      status: 'success',
-      message: 'Ingest completed',
-      completedAt: now,
-      stats: summaryStats,
-      comparison,
-    });
-  } catch (error) {
-    console.error('Ingest failed:', error);
-
-    // Persist failure (best-effort — don't let this swallow the original error)
-    try {
+      // 8. Persist full stats to ingestRuns
       await db
         .update(ingestRuns)
         .set({
-          completedAt: new Date().toISOString(),
-          status: 'failure',
-          durationSec: Math.round((Date.now() - Date.parse(startedAt)) / 1000),
-          errorMessage: String(error),
+          completedAt: now,
+          status: 'success',
+          durationSec: stats.durationSec,
+          regionsPruned: stats.regionsPruned,
+          workoutsPruned: stats.workoutsPruned,
+          regionsSeeded: stats.regionsSeeded,
+          regionsSkippedFresh: stats.regionsSkippedFresh,
+          workoutsSeeded: stats.workoutsSeeded,
+          workoutsDeduplicated: stats.workoutsDeduplicated,
+          workoutsSkipped: stats.workoutsSkipped,
+          workoutBatches: stats.workoutBatches,
+          workoutsSkippedFresh: stats.skipBreakdown.fresh,
+          workoutsSkippedMissingType: stats.skipBreakdown.missingType,
+          workoutsSkippedMissingAo: stats.skipBreakdown.missingAo,
+          workoutsSkippedMissingRegion: stats.skipBreakdown.missingRegion,
+          workoutsSkippedMissingLocation: stats.skipBreakdown.missingLocation,
+          workoutsSkippedMissingGroup: stats.skipBreakdown.missingGroup,
+          regionsEnriched: stats.regionsEnriched,
+          workoutRegionBreakdown: JSON.stringify(stats.workoutRegionBreakdown),
         })
         .where(eq(ingestRuns.id, runRow.id));
-    } catch (persistError) {
-      console.error('Failed to persist ingest failure:', persistError);
-    }
 
-    // Send failure notification
+      // 9. Build Slack message
+      const fmt = (n: number) => n.toLocaleString('en-US');
+
+      const capList = (
+        items: { text: string; slug: string }[],
+        max: number
+      ) => {
+        const formatted = items.map((item) => slackLink(item.slug, item.text));
+        return formatted.length <= max
+          ? formatted.join(', ')
+          : `${formatted.slice(0, max).join(', ')} _and ${items.length - max} more_`;
+      };
+
+      const formatBreakdown = (
+        breakdown: Record<string, number>,
+        max: number
+      ) => {
+        const entries = Object.entries(breakdown).sort(
+          ([, a], [, b]) => b - a
+        );
+        const shown = entries.slice(0, max);
+        const lines = shown.map(
+          ([name, count]) =>
+            `  • ${slackLink(kebabCase(name), name)}: ${fmt(count)}`
+        );
+        if (entries.length > max) {
+          lines.push(`  • _and ${entries.length - max} more regions_`);
+        }
+        return lines.join('\n');
+      };
+
+      const regionsPrunedLine =
+        stats.regionsPruned > 0
+          ? `*Regions pruned (${fmt(stats.regionsPruned)}):* ${capList(
+              stats.regionsPrunedNames.map((n) => ({
+                text: n,
+                slug: kebabCase(n),
+              })),
+              10
+            )}`
+          : `*Regions pruned:* 0`;
+
+      const workoutsPrunedLine =
+        stats.workoutsPruned > 0
+          ? `*Workouts pruned (${fmt(stats.workoutsPruned)}):* ${capList(
+              stats.workoutsPrunedItems.map((w) => ({
+                text: w.name,
+                slug: kebabCase(w.regionName),
+              })),
+              10
+            )}`
+          : `*Workouts pruned:* 0`;
+
+      const regionsSeededLine =
+        stats.regionsSeeded > 0
+          ? `*Regions seeded (${fmt(stats.regionsSeeded)}):* ${capList(
+              stats.regionsSeededNames.map((n) => ({
+                text: n,
+                slug: kebabCase(n),
+              })),
+              10
+            )}` +
+            (stats.regionsSkippedFresh > 0
+              ? ` (${fmt(stats.regionsSkippedFresh)} skipped fresh)`
+              : '')
+          : `*Regions seeded:* 0` +
+            (stats.regionsSkippedFresh > 0
+              ? ` (${fmt(stats.regionsSkippedFresh)} skipped fresh)`
+              : '');
+
+      const workoutsSeededLine =
+        `*Workouts seeded (${fmt(stats.workoutsSeeded)}):* ${fmt(stats.workoutsSeeded)} in ${fmt(stats.workoutBatches)} batch(es)` +
+        (stats.workoutsDeduplicated > 0
+          ? ` (${fmt(stats.workoutsDeduplicated)} deduplicated)`
+          : '') +
+        (stats.workoutsSkipped > 0
+          ? ` (${fmt(stats.workoutsSkipped)} skipped)`
+          : '');
+
+      const breakdownSection =
+        Object.keys(stats.workoutRegionBreakdown).length > 0
+          ? '\n' + formatBreakdown(stats.workoutRegionBreakdown, 15)
+          : '';
+
+      // Skip breakdown line
+      const sb = stats.skipBreakdown;
+      const skipBreakdownLine =
+        stats.workoutsSkipped > 0
+          ? `*Skip breakdown:* fresh=${fmt(sb.fresh)}, missingType=${fmt(sb.missingType)}, missingAo=${fmt(sb.missingAo)}, missingRegion=${fmt(sb.missingRegion)}, missingLocation=${fmt(sb.missingLocation)}, missingGroup=${fmt(sb.missingGroup)}`
+          : '';
+
+      // Comparison lines
+      const comparisonLines: string[] = [];
+      if (comparison.deltas) {
+        const d = comparison.deltas;
+        const sign = d.workoutsSeeded >= 0 ? '+' : '';
+        const pctStr =
+          d.workoutsSeededPct !== 0
+            ? ` (${sign}${d.workoutsSeededPct.toFixed(0)}%)`
+            : '';
+        comparisonLines.push(
+          `*vs last run:* workouts ${sign}${fmt(d.workoutsSeeded)}${pctStr}, skip rate ${(comparison.skipRate * 100).toFixed(1)}%`
+        );
+      }
+      if (comparison.rolling.sampleSize >= 2) {
+        comparisonLines.push(
+          `*${comparison.rolling.sampleSize}-run avg:* ${fmt(Math.round(comparison.rolling.mean))} seeded (stddev ${fmt(Math.round(comparison.rolling.stddev))})`
+        );
+      }
+      if (comparison.anomaly.flagged) {
+        comparisonLines.push(
+          `:warning: *ANOMALY:* ${comparison.anomaly.message}`
+        );
+      }
+
+      const comparisonSection =
+        comparisonLines.length > 0 ? '\n' + comparisonLines.join('\n') : '';
+
+      await sendSlackNotification(
+        `:white_check_mark: F3 Region Pages daily ingest completed\n\n` +
+          `*Duration:* ${durationSec}s\n` +
+          `${regionsPrunedLine}\n` +
+          `${workoutsPrunedLine}\n` +
+          `${regionsSeededLine}\n` +
+          `${workoutsSeededLine}${breakdownSection}\n` +
+          (skipBreakdownLine ? `${skipBreakdownLine}\n` : '') +
+          `*Regions enriched:* ${fmt(stats.regionsEnriched)}` +
+          comparisonSection
+      );
+
+      const {
+        regionsPrunedNames: _rpn, // eslint-disable-line @typescript-eslint/no-unused-vars
+        workoutsPrunedItems: _wpi, // eslint-disable-line @typescript-eslint/no-unused-vars
+        regionsSeededNames: _rsn, // eslint-disable-line @typescript-eslint/no-unused-vars
+        workoutRegionBreakdown: _wrb, // eslint-disable-line @typescript-eslint/no-unused-vars
+        skipBreakdown: _sb, // eslint-disable-line @typescript-eslint/no-unused-vars
+        ...summaryStats
+      } = stats;
+
+      return NextResponse.json({
+        status: 'success',
+        message: 'Ingest completed',
+        completedAt: now,
+        stats: summaryStats,
+        comparison,
+      });
+    } catch (error) {
+      console.error('Ingest failed:', error);
+
+      // Persist failure (best-effort — don't let this swallow the original error)
+      try {
+        await db
+          .update(ingestRuns)
+          .set({
+            completedAt: new Date().toISOString(),
+            status: 'failure',
+            durationSec: Math.round(
+              (Date.now() - Date.parse(startedAt)) / 1000
+            ),
+            errorMessage: String(error),
+          })
+          .where(eq(ingestRuns.id, runRow.id));
+      } catch (persistError) {
+        console.error('Failed to persist ingest failure:', persistError);
+      }
+
+      // Send failure notification
+      await sendSlackNotification(
+        `:x: F3 Region Pages daily ingest failed: ${escapeSlack(String(error))}`
+      );
+
+      return NextResponse.json(
+        { status: 'error', message: String(error) },
+        { status: 500 }
+      );
+    }
+  } catch (outerError) {
+    // Catches errors in the preamble (idempotency check, ingestRuns insert)
+    // that would otherwise crash without any Slack notification
+    console.error('Ingest handler crashed:', outerError);
+
     await sendSlackNotification(
-      `:x: F3 Region Pages daily ingest failed: ${escapeSlack(String(error))}`
+      `:x: F3 Region Pages ingest handler crashed (pre-ingest): ${escapeSlack(String(outerError))}`
     );
 
     return NextResponse.json(
-      { status: 'error', message: String(error) },
+      { status: 'error', message: String(outerError) },
       { status: 500 }
     );
   }

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -151,7 +151,6 @@ export async function POST(request: NextRequest) {
       // 7. Get comparison analytics (before persisting success so current run isn't in the window)
       const comparison = await getIngestComparison({
         workoutsSeeded: stats.workoutsSeeded,
-        workoutsDeduplicated: stats.workoutsDeduplicated,
         workoutsSkipped: stats.workoutsSkipped,
         regionsSeeded: stats.regionsSeeded,
         durationSec: stats.durationSec,

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -109,8 +109,19 @@ export async function POST(request: NextRequest) {
       .returning({ id: ingestRuns.id });
 
     // 4. Pre-flight: verify warehouse connectivity before running the pipeline
-    const warehousePool = getWarehousePool();
-    const warehouseReachable = await warehousePool.isReachable();
+    const warehousePool = await getWarehousePool();
+    let warehouseReachable = false;
+    try {
+      const client = await warehousePool.connect();
+      try {
+        await client.query('SELECT 1');
+        warehouseReachable = true;
+      } finally {
+        client.release();
+      }
+    } catch {
+      warehouseReachable = false;
+    }
     if (!warehouseReachable) {
       const msg =
         'Warehouse database is unreachable after retry attempts — aborting ingest';

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -199,9 +199,7 @@ export async function POST(request: NextRequest) {
         breakdown: Record<string, number>,
         max: number
       ) => {
-        const entries = Object.entries(breakdown).sort(
-          ([, a], [, b]) => b - a
-        );
+        const entries = Object.entries(breakdown).sort(([, a], [, b]) => b - a);
         const shown = entries.slice(0, max);
         const lines = shown.map(
           ([name, count]) =>

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,7 +8,8 @@ export function loadEnvConfig() {
     throw new Error(`POSTGRES_URL is not set in .env.${env}`);
   }
 
-  if (!process.env.F3_DATA_WAREHOUSE_URL) {
+  const warehouseMode = process.env.WAREHOUSE_DB_CONNECTION_MODE ?? 'direct';
+  if (warehouseMode === 'direct' && !process.env.F3_DATA_WAREHOUSE_URL) {
     throw new Error(`F3_DATA_WAREHOUSE_URL is not set in .env.${env}`);
   }
 


### PR DESCRIPTION
## Summary

Resolves multi-day ETIMEDOUT failures in the daily ingest pipeline. The root cause was the F3 Data Warehouse admins locking down direct IP access to `35.239.19.124:5432` and switching to a Google Cloud SQL proxy. This PR addresses the issue at multiple layers:

- **Cloud SQL Connector**: Integrates `@google-cloud/cloud-sql-connector` as the production connection method (`WAREHOUSE_DB_CONNECTION_MODE=connector`), matching Moneyball's approach in PR #86 but combined with our hardening. Secrets already loaded in Firebase by Moneyball: `f3data:us-central1:f3data`
- **RetryPool**: Custom `pg.Pool` subclass with automatic connection retry (3 attempts, exponential backoff 2s→4s→8s) for transient errors (ETIMEDOUT, ECONNRESET, ECONNREFUSED). Applied to direct mode as defense-in-depth.
- **Pool hardening**: Warehouse pool capped at max 3 connections, 30s idle/connect timeout, 60s statement timeout. Applied to both connector and direct modes.
- **Pre-flight check**: Ingest route verifies warehouse connectivity before running the pipeline, failing fast with a 503 instead of crashing mid-pipeline.
- **Race-condition-safe init**: Async `getDb()` singleton uses a promise guard to prevent concurrent callers from creating duplicate pools.
- **Reduced concurrency**: `UPSERT_CONCURRENCY` reduced from 8→2, batch size from 1000→500.
- **Async refactor**: All scripts migrated from sync `db` import to async `getDb()` pattern for Cloud SQL connector compatibility.
- **Silent failure fix**: Ingest handler preamble wrapped in try/catch for Slack notifications.
- **Prune deactivated AOs**: Workouts properly pruned when parent AO is deactivated.
- **Post-mortem**: `docs/postmortems/2026-04-06-etimedout-ingest-failures.md`

### Timeline

1. **v1** — Pool config (max 5, 10s timeouts, concurrency 4): 10s timeout too aggressive for GCP
2. **v2** — Tighter pool (max 3, 30s timeouts, concurrency 2): Still failed — direct IP blocked
3. **v3** — RetryPool with exponential backoff: Defense-in-depth, but TCP packets still blocked
4. **v4** — Cloud SQL connector integration: Root cause fix. **Validated in production** — 525 regions, 6,382 workouts seeded in 151s ✅

## Test plan

- [x] Build passes
- [x] Tests pass (37 tests across 4 suites)
- [x] Lint clean
- [x] Typecheck clean
- [x] Format check clean
- [x] Pool config module exports WAREHOUSE_POOL_CONFIG and SUPABASE_POOL_CONFIG
- [x] RetryPool tests: retries on ETIMEDOUT, ECONNRESET; no retry on auth errors; exhausts retries
- [x] Warehouse max connections ≤ 3
- [x] Default UPSERT_CONCURRENCY is 2
- [x] Ingest route preserves ?force=true override logic
- [x] Post-mortem document exists at docs/postmortems/
- [x] **Verified in production**: force=true ingest completed successfully via Cloud SQL connector (525 regions, 6,382 workouts, 151s) — [Slack notification](https://f3nation-dev.slack.com/archives/C0AD49GGNQ0/p1775573998237039)

🤖 Generated with [Claude Code](https://claude.com/claude-code)