### PR TITLE
Add Cloud Run + Terraform deployment (alongside Firebase)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+.next
+.git
+.github
+.env
+.env.*
+!.env.example
+npm-debug.log*
+firebase-debug.log*
+firebase-debug.*.log
+.firebase
+infra
+coverage
+.DS_Store
+*.local
+.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for the F3 region-pages Next.js app, targeting Cloud Run.
+#
+# `next build` runs generateStaticParams() against the databases, so the build
+# needs POSTGRES_URL and F3_DATA_WAREHOUSE_URL. These are passed as BuildKit
+# secrets (never baked into a layer):
+#
+#   DOCKER_BUILDKIT=1 docker build \
+#     --secret id=postgres_url,src=./.secrets/postgres_url \
+#     --secret id=warehouse_url,src=./.secrets/warehouse_url \
+#     -t <region>-docker.pkg.dev/<project>/<repo>/web:<tag> .
+#
+FROM node:20-bookworm-slim AS builder
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /app
+
+COPY . .
+
+# Skip lifecycle scripts: postinstall runs `skills:check` (dev tooling) which is
+# unnecessary for a production build and may require network/state we don't have.
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# Build-time DB access for generateStaticParams. Secrets are mounted only for
+# this RUN and are not persisted into the image.
+RUN --mount=type=secret,id=postgres_url \
+    --mount=type=secret,id=warehouse_url \
+    POSTGRES_URL="$(cat /run/secrets/postgres_url)" \
+    F3_DATA_WAREHOUSE_URL="$(cat /run/secrets/warehouse_url)" \
+    pnpm build
+
+FROM node:20-bookworm-slim AS runner
+
+ENV NODE_ENV=production
+ENV PORT=8080
+ENV HOSTNAME=0.0.0.0
+
+WORKDIR /app
+
+# Next.js standalone output: server.js + a pruned node_modules live at the root
+# of .next/standalone, with static assets and public/ copied alongside.
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+EXPOSE 8080
+
+CMD ["node", "server.js"]

--- a/infra/terraform/cloud-run/.gitignore
+++ b/infra/terraform/cloud-run/.gitignore
@@ -1,0 +1,10 @@
+# Real variable values (including secrets) — never commit.
+terraform.tfvars
+*.auto.tfvars
+
+# Terraform working state.
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log

--- a/infra/terraform/cloud-run/README.md
+++ b/infra/terraform/cloud-run/README.md
@@ -1,0 +1,90 @@
+# f3-region-pages — Cloud Run (Terraform)
+
+Deploys the region-pages Next.js app to **Google Cloud Run** in the
+**`region-pages`** GCP project, replacing the opaque Firebase App Hosting
+mechanism with explicit infrastructure as code.
+
+This stack runs **alongside** the existing Firebase App Hosting backend during
+the migration. It makes **no DNS change** — `regions.f3nation.com` keeps pointing
+at Firebase until the F3 Nation dev team (Tackle) performs the cutover.
+
+## What it provisions
+
+- Artifact Registry Docker repo (`f3-region-pages`)
+- A runtime service account (`f3-region-pages-run`) with `roles/cloudsql.client`
+  (for the warehouse Cloud SQL connector)
+- The 9 runtime secrets, **recreated** as Terraform-managed `…-tf` secrets in
+  Secret Manager (see "Secret duplication" below)
+- A `google_cloud_run_v2_service` (`f3-region-pages`) on port 8080, public, with
+  all secrets wired in plus `WAREHOUSE_DB_CONNECTION_MODE=connector`
+- When `service_domain` is set: an external HTTPS load balancer (`lb.tf`) — static
+  anycast IP, serverless NEG, Google-managed TLS cert, and an HTTP→HTTPS redirect
+
+## Prerequisites
+
+- `gcloud` authenticated as an account with access to `region-pages`
+  (`gcloud config set account patrick@pstaylor.net && gcloud config set project region-pages`)
+- `terraform >= 1.5`, Docker with BuildKit
+
+## Deploy
+
+```bash
+cd infra/terraform/cloud-run
+
+# 0. One-time: create the remote state bucket (matches versions.tf backend).
+gcloud storage buckets create gs://region-pages-tfstate \
+  --project=region-pages --location=us-central1 --uniform-bucket-level-access
+gcloud storage buckets update gs://region-pages-tfstate --versioning
+
+# 1. Seed terraform.tfvars from the existing Firebase secrets.
+cp terraform.tfvars.example terraform.tfvars
+# For each key, paste the value from:
+#   gcloud secrets versions access latest --secret=<name> --project=region-pages
+
+# 2. Init + create the Artifact Registry repo first (the image lands there).
+terraform init
+terraform apply -target=google_artifact_registry_repository.containers
+
+# 3. Build and push the image (build needs DB access for generateStaticParams).
+gcloud auth configure-docker us-central1-docker.pkg.dev
+mkdir -p .secrets
+gcloud secrets versions access latest --secret=postgres-url        --project=region-pages > .secrets/postgres_url
+gcloud secrets versions access latest --secret=f3-data-warehouse-url --project=region-pages > .secrets/warehouse_url
+DOCKER_BUILDKIT=1 docker build \
+  --secret id=postgres_url,src=.secrets/postgres_url \
+  --secret id=warehouse_url,src=.secrets/warehouse_url \
+  -t us-central1-docker.pkg.dev/region-pages/f3-region-pages/web:v1 \
+  ../../..
+docker push us-central1-docker.pkg.dev/region-pages/f3-region-pages/web:v1
+rm -rf .secrets
+
+# 4. Set `image` in terraform.tfvars to the pushed tag, then apply the full stack.
+terraform apply
+
+# 5. Verify.
+terraform output service_url
+```
+
+## Secret duplication (migration debt)
+
+Firebase App Hosting created Secret Manager secrets named `postgres-url`,
+`cron-secret`, etc. This stack creates **parallel** copies suffixed `-tf`
+(`postgres-url-tf`, …) so both deployments work during the messy middle. Once
+Cloud Run is the production path and Firebase App Hosting is decommissioned,
+**delete the original (un-suffixed) Firebase secrets**. Terraform is the source
+of truth from that point on.
+
+## DNS cutover (hand-off to Tackle)
+
+The custom domain is served by an external HTTPS load balancer rather than a
+Cloud Run domain mapping — this avoids Search Console / Webmaster domain
+verification. The Google-managed certificate validates automatically once the
+domain resolves to the load balancer IP, so the only DNS change is one A record:
+
+1. `terraform apply` with `service_domain` set (allocates the static IP + LB).
+2. Hand the `dns_handoff` output to the F3 Nation dev team (Tackle), e.g.:
+   `A  regions.f3nation.com  ->  <load_balancer_ip>  (TTL 300)`.
+3. Once the A record resolves, the managed cert provisions in ~15–60 min and the
+   LB serves HTTPS. Verify with `curl -I https://regions.f3nation.com/`.
+
+No `regions.f3nation.com` change is made by this stack — Tackle owns the zone.

--- a/infra/terraform/cloud-run/lb.tf
+++ b/infra/terraform/cloud-run/lb.tf
@@ -1,0 +1,113 @@
+# Global external Application Load Balancer in front of the Cloud Run service.
+#
+# Why not a Cloud Run domain mapping? Domain mappings require Search Console /
+# Webmaster ownership verification of the domain before Google will activate
+# them. A load balancer with a Google-managed certificate validates the domain
+# automatically once its A record resolves to the LB IP — so the only DNS change
+# handed to the F3 Nation dev team (Tackle) is a single A record to a stable
+# anycast IP.
+#
+# All resources are gated on var.service_domain: empty (default) builds nothing.
+
+locals {
+  enable_lb = var.service_domain == "" ? 0 : 1
+}
+
+# Stable anycast IP — this is the value Tackle points the A record at.
+resource "google_compute_global_address" "lb" {
+  count   = local.enable_lb
+  project = var.project_id
+  name    = "${var.service_name}-lb-ip"
+}
+
+# Serverless NEG targeting the Cloud Run service.
+resource "google_compute_region_network_endpoint_group" "serverless" {
+  count                 = local.enable_lb
+  project               = var.project_id
+  name                  = "${var.service_name}-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.app.name
+  }
+}
+
+resource "google_compute_backend_service" "lb" {
+  count                 = local.enable_lb
+  project               = var.project_id
+  name                  = "${var.service_name}-backend"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "HTTPS"
+
+  backend {
+    group = google_compute_region_network_endpoint_group.serverless[0].id
+  }
+}
+
+# Google-managed TLS certificate. Provisions automatically once DNS resolves to
+# google_compute_global_address.lb; until then it sits in PROVISIONING.
+resource "google_compute_managed_ssl_certificate" "lb" {
+  count   = local.enable_lb
+  project = var.project_id
+  name    = "${var.service_name}-cert"
+
+  managed {
+    domains = [var.service_domain]
+  }
+}
+
+resource "google_compute_url_map" "lb" {
+  count           = local.enable_lb
+  project         = var.project_id
+  name            = "${var.service_name}-urlmap"
+  default_service = google_compute_backend_service.lb[0].id
+}
+
+resource "google_compute_target_https_proxy" "lb" {
+  count            = local.enable_lb
+  project          = var.project_id
+  name             = "${var.service_name}-https-proxy"
+  url_map          = google_compute_url_map.lb[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.lb[0].id]
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  count                 = local.enable_lb
+  project               = var.project_id
+  name                  = "${var.service_name}-https"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.lb[0].id
+  ip_address            = google_compute_global_address.lb[0].id
+}
+
+# Port 80 -> 443 redirect so plain-HTTP requests upgrade to HTTPS.
+resource "google_compute_url_map" "redirect" {
+  count   = local.enable_lb
+  project = var.project_id
+  name    = "${var.service_name}-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+resource "google_compute_target_http_proxy" "redirect" {
+  count   = local.enable_lb
+  project = var.project_id
+  name    = "${var.service_name}-http-proxy"
+  url_map = google_compute_url_map.redirect[0].id
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  count                 = local.enable_lb
+  project               = var.project_id
+  name                  = "${var.service_name}-http"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.redirect[0].id
+  ip_address            = google_compute_global_address.lb[0].id
+}

--- a/infra/terraform/cloud-run/main.tf
+++ b/infra/terraform/cloud-run/main.tf
@@ -1,0 +1,121 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
+resource "google_project_service" "required" {
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "sqladmin.googleapis.com",
+    "compute.googleapis.com",
+  ])
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "containers" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  description   = "Container images for the F3 region-pages app."
+  format        = "DOCKER"
+  labels        = var.service_labels
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = "f3-region-pages-run"
+  display_name = "F3 region-pages Cloud Run runtime"
+}
+
+# The app reaches the warehouse via the Cloud SQL connector at runtime
+# (WAREHOUSE_DB_CONNECTION_MODE=connector), which authenticates as this SA.
+resource "google_project_iam_member" "runtime_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_cloud_run_v2_service" "app" {
+  name                = var.service_name
+  location            = var.region
+  ingress             = var.ingress
+  labels              = var.service_labels
+  deletion_protection = false
+
+  template {
+    service_account = google_service_account.runtime.email
+
+    scaling {
+      min_instance_count = var.min_instance_count
+      max_instance_count = var.max_instance_count
+    }
+
+    containers {
+      image = var.image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cpu
+          memory = var.memory
+        }
+      }
+
+      # Plain (non-secret) runtime configuration.
+      env {
+        name  = "WAREHOUSE_DB_CONNECTION_MODE"
+        value = "connector"
+      }
+
+      # Secret-backed runtime configuration.
+      dynamic "env" {
+        for_each = local.runtime_secrets
+        content {
+          name = env.value
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.runtime[env.key].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.required,
+    google_secret_manager_secret_version.runtime,
+    google_secret_manager_secret_iam_member.runtime_accessor,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "invoker" {
+  count    = var.allow_unauthenticated ? 1 : 0
+  project  = var.project_id
+  location = google_cloud_run_v2_service.app.location
+  name     = google_cloud_run_v2_service.app.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Custom-domain serving is handled by an external HTTPS load balancer in lb.tf
+# (serverless NEG + Google-managed cert), not by a Cloud Run domain mapping.
+# The load balancer avoids Webmaster/Search Console domain verification: the
+# managed certificate validates automatically once DNS points at the LB IP, so
+# the DNS hand-off is a single A record. See lb.tf and the `load_balancer_ip`
+# output.

--- a/infra/terraform/cloud-run/outputs.tf
+++ b/infra/terraform/cloud-run/outputs.tf
@@ -1,0 +1,31 @@
+output "service_url" {
+  description = "Cloud Run *.run.app URL for the region-pages app."
+  value       = google_cloud_run_v2_service.app.uri
+}
+
+output "artifact_registry_repository_url" {
+  description = "Artifact Registry path prefix for docker pushes."
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.containers.repository_id}"
+}
+
+output "runtime_service_account_email" {
+  description = "Runtime service account email for the Cloud Run service."
+  value       = google_service_account.runtime.email
+}
+
+output "load_balancer_ip" {
+  description = "Static anycast IP of the external HTTPS load balancer. Hand this to the F3 Nation dev team (Tackle): create an A record for service_domain pointing here. Empty until service_domain is set."
+  value       = try(google_compute_global_address.lb[0].address, "")
+}
+
+output "managed_certificate_domains" {
+  description = "Domains on the Google-managed TLS certificate. The cert auto-provisions once the A record resolves to load_balancer_ip."
+  value       = try(google_compute_managed_ssl_certificate.lb[0].managed[0].domains, [])
+}
+
+output "dns_handoff" {
+  description = "Copy/paste DNS instruction for Tackle."
+  value = var.service_domain == "" ? "service_domain not set — no DNS change to hand off yet." : (
+    "Create an A record: ${var.service_domain} -> ${try(google_compute_global_address.lb[0].address, "(pending apply)")} (TTL 300). HTTPS cert auto-provisions within ~15-60 min after it resolves."
+  )
+}

--- a/infra/terraform/cloud-run/secrets.tf
+++ b/infra/terraform/cloud-run/secrets.tf
@@ -1,0 +1,49 @@
+locals {
+  # Logical (Firebase) secret name => Cloud Run environment variable name.
+  # The Terraform-managed copies are created with a "-tf" suffix so they coexist
+  # with the Firebase App Hosting-managed originals during the migration.
+  runtime_secrets = {
+    "postgres-url"                        = "POSTGRES_URL"
+    "f3-data-warehouse-url"               = "F3_DATA_WAREHOUSE_URL"
+    "cloud-sql-warehouse-connection-name" = "CLOUD_SQL_WAREHOUSE_CONNECTION_NAME"
+    "warehouse-db-user"                   = "WAREHOUSE_DB_USER"
+    "warehouse-db-password"               = "WAREHOUSE_DB_PASSWORD"
+    "warehouse-db-name"                   = "WAREHOUSE_DB_NAME"
+    "cron-secret"                         = "CRON_SECRET"
+    "slack-bot-auth-token"                = "SLACK_BOT_AUTH_TOKEN"
+    "slack-channel-id"                    = "SLACK_CHANNEL_ID"
+  }
+
+  secret_suffix = "-tf"
+}
+
+resource "google_secret_manager_secret" "runtime" {
+  for_each = local.runtime_secrets
+
+  project   = var.project_id
+  secret_id = "${each.key}${local.secret_suffix}"
+  labels    = var.service_labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret_version" "runtime" {
+  for_each = local.runtime_secrets
+
+  secret      = google_secret_manager_secret.runtime[each.key].id
+  secret_data = var.secret_values[each.key]
+}
+
+# Allow the Cloud Run runtime service account to read each secret.
+resource "google_secret_manager_secret_iam_member" "runtime_accessor" {
+  for_each = local.runtime_secrets
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.runtime[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}

--- a/infra/terraform/cloud-run/terraform.tfvars.example
+++ b/infra/terraform/cloud-run/terraform.tfvars.example
@@ -1,0 +1,33 @@
+project_id                      = "region-pages"
+region                          = "us-central1"
+artifact_registry_repository_id = "f3-region-pages"
+service_name                    = "f3-region-pages"
+
+# Set after building and pushing the image (see README).
+image = "us-central1-docker.pkg.dev/region-pages/f3-region-pages/web:v1"
+
+# Set to the custom domain to build the external HTTPS load balancer (serverless
+# NEG + Google-managed cert). Leave empty to skip the LB entirely. When set, the
+# `load_balancer_ip` / `dns_handoff` outputs give Tackle the A record to create.
+service_domain = "regions.f3nation.com"
+
+min_instance_count = 0
+max_instance_count = 4
+cpu                = "1"
+memory             = "512Mi"
+
+# Recreated runtime secrets, keyed by their logical (Firebase) names. Seed these
+# from the existing Firebase-managed secrets:
+#   gcloud secrets versions access latest --secret=postgres-url --project=region-pages
+# DO NOT COMMIT real values — terraform.tfvars is gitignored.
+secret_values = {
+  "postgres-url"                        = "REPLACE_ME"
+  "f3-data-warehouse-url"               = "REPLACE_ME"
+  "cloud-sql-warehouse-connection-name" = "REPLACE_ME"
+  "warehouse-db-user"                   = "REPLACE_ME"
+  "warehouse-db-password"               = "REPLACE_ME"
+  "warehouse-db-name"                   = "REPLACE_ME"
+  "cron-secret"                         = "REPLACE_ME"
+  "slack-bot-auth-token"                = "REPLACE_ME"
+  "slack-channel-id"                    = "REPLACE_ME"
+}

--- a/infra/terraform/cloud-run/variables.tf
+++ b/infra/terraform/cloud-run/variables.tf
@@ -1,0 +1,96 @@
+variable "project_id" {
+  description = "Google Cloud project ID that hosts the region-pages service."
+  type        = string
+  default     = "region-pages"
+}
+
+variable "region" {
+  description = "Google Cloud region for Cloud Run and Artifact Registry."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry Docker repository that stores the region-pages image."
+  type        = string
+  default     = "f3-region-pages"
+}
+
+variable "service_name" {
+  description = "Cloud Run service name for the region-pages app."
+  type        = string
+  default     = "f3-region-pages"
+}
+
+variable "image" {
+  description = "Fully-qualified container image for the region-pages service, e.g. us-central1-docker.pkg.dev/region-pages/f3-region-pages/web:v1."
+  type        = string
+}
+
+variable "service_domain" {
+  description = "Optional domain mapped directly to the Cloud Run service (e.g. regions.f3nation.com). Left empty until the F3 Nation dev team (Tackle) is ready to make the DNS change; the domain mapping resource is disabled while empty."
+  type        = string
+  default     = ""
+}
+
+variable "ingress" {
+  description = "Cloud Run ingress policy."
+  type        = string
+  default     = "INGRESS_TRAFFIC_ALL"
+}
+
+variable "allow_unauthenticated" {
+  description = "Whether to make the service publicly accessible (allUsers can invoke)."
+  type        = bool
+  default     = true
+}
+
+variable "min_instance_count" {
+  description = "Minimum running instances (0 = scale to zero, matching the Firebase App Hosting config)."
+  type        = number
+  default     = 0
+}
+
+variable "max_instance_count" {
+  description = "Maximum running instances."
+  type        = number
+  default     = 4
+}
+
+variable "cpu" {
+  description = "CPU allocation per instance."
+  type        = string
+  default     = "1"
+}
+
+variable "memory" {
+  description = "Memory allocation per instance."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "service_labels" {
+  description = "Labels applied to the Artifact Registry repository and Cloud Run service."
+  type        = map(string)
+  default = {
+    application = "f3-region-pages"
+    managed_by  = "terraform"
+  }
+}
+
+variable "secret_values" {
+  description = <<-EOT
+    Values for the Terraform-managed runtime secrets, keyed by their logical
+    (Firebase) secret name. These are recreated as new `<name>-tf` secrets in
+    Secret Manager to coexist with the Firebase App Hosting-managed originals
+    during the migration. Supply via a gitignored terraform.tfvars seeded from
+    `gcloud secrets versions access latest --secret=<name>`.
+
+    Required keys: postgres-url, f3-data-warehouse-url,
+    cloud-sql-warehouse-connection-name, warehouse-db-user,
+    warehouse-db-password, warehouse-db-name, cron-secret,
+    slack-bot-auth-token, slack-channel-id.
+  EOT
+  type        = map(string)
+  sensitive   = true
+}

--- a/infra/terraform/cloud-run/versions.tf
+++ b/infra/terraform/cloud-run/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  # Remote state in the region-pages project. Bucket is created out-of-band
+  # before `terraform init` (see README). State for this stack lives under the
+  # cloud-run/ prefix so other stacks can share the bucket later.
+  backend "gcs" {
+    bucket = "region-pages-tfstate"
+    prefix = "cloud-run"
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle (.next/standalone) for the Cloud Run
+  // Docker image. Firebase App Hosting did not require this; the Dockerfile does.
+  output: 'standalone',
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

Migrates **region-pages** off **Firebase App Hosting** onto **vanilla GCP Cloud Run**, defined as **Terraform infrastructure-as-code** in this repo. This is the first step toward eventually folding region-pages into the F3 Nation monorepo.

The new stack is **already deployed and verified** in the `region-pages` GCP project and runs **alongside** the existing Firebase App Hosting backend. **No production DNS change is made** — `regions.f3nation.com` continues to serve via Firebase until cutover.

- Live (non-prod) Cloud Run URL: `https://f3-region-pages-mx5ollfbiq-uc.a.run.app`

## Changes

- **`next.config.ts`** — `output: 'standalone'` for a slim container image.
- **`Dockerfile` / `.dockerignore`** — multi-stage build (Node 20, pnpm 9). `POSTGRES_URL` + `F3_DATA_WAREHOUSE_URL` are mounted as BuildKit secrets so `generateStaticParams` can prerender ~530 region pages at build time (never baked into a layer).
- **`infra/terraform/cloud-run/`** — Artifact Registry repo, runtime service account (`+roles/cloudsql.client` for the warehouse connector), the 9 runtime secrets, the public Cloud Run service (port 8080, scale 0→4), and an **optional external HTTPS load balancer** (static IP + serverless NEG + Google-managed cert + HTTP→HTTPS redirect) for the custom domain. Remote state in `gs://region-pages-tfstate`.

## Custom domain / DNS

The custom domain is fronted by an **external HTTPS load balancer** rather than a Cloud Run domain mapping — this avoids Search Console / Webmaster domain verification. The managed cert validates automatically once DNS resolves to the LB IP, so the hand-off is a **single A record**:

```
A   regions.f3nation.com   ->   8.233.224.179   (TTL 300)
```

To be coordinated with the F3 Nation dev team (Tackle), who own the DNS zone.

## Migration debt (the "messy middle")

- The 9 runtime secrets are **recreated** as Terraform-managed `*-tf` Secret Manager secrets, coexisting with the Firebase-managed originals. Once Cloud Run is the production path and Firebase is decommissioned, delete the un-suffixed originals.
- Cron ingest (Upstash QStash → `/api/ingest`) is unchanged.

## Verification

- `terraform validate` clean; full stack applied successfully.
- Cloud Run URL: `/` → 200, `/abilene` → 200 (warehouse-backed SSG), `POST /api/ingest` → 401 without `CRON_SECRET`, unknown slug → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
