### PR TITLE
fix: allow f3-public-images GCS bucket for region logos

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/backblast-images/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
+        port: '',
+        pathname: '/f3-public-images/**',
+      },
     ],
   },
   // Improve cache handling and build consistency

--- a/src/components/RegionContent.tsx
+++ b/src/components/RegionContent.tsx
@@ -214,7 +214,8 @@ export function RegionContent({
     regionDescription && regionDescription.trim().length > 0
       ? regionDescription
       : defaultRegionDescription;
-  const isFallbackLogo = !image;
+  const [logoError, setLogoError] = useState(false);
+  const isFallbackLogo = !image || logoError;
   const sanitizedDescription = useMemo(
     () => sanitizeHtmlToReactNodes(descriptionSource),
     [descriptionSource]
@@ -273,6 +274,7 @@ export function RegionContent({
               height={150}
               className="w-150 h-150 mb-4 mr-2"
               priority={true}
+              onError={() => setLogoError(true)}
             />
           )}
           F3 {regionName}


### PR DESCRIPTION
Region logos stored at storage.googleapis.com/f3-public-images/org-logos/ were not in next.config.ts remotePatterns, causing Next.js image optimization to return a 400 "url parameter is not allowed" error.

Also adds an onError fallback in RegionContent so a broken logo URL degrades gracefully to the default F3 logo instead of a broken image.