### PR TITLE
fix: invalidate unstable_cache after ingest completes

### DIFF
--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,5 +1,6 @@
 import { kebabCase } from 'lodash';
 import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
 import { eq } from 'drizzle-orm';
 
 import { db } from '../../../../drizzle/db';
@@ -160,6 +161,9 @@ export async function POST(request: NextRequest) {
       const seedRegionsStats = await seedRegions();
       const seedWorkoutsStats = await seedWorkouts();
       const enrichRegionsStats = await enrichRegions();
+
+      revalidateTag('region-workouts');
+      revalidateTag('regions');
 
       const durationSec = Math.round((Date.now() - startTime) / 1000);
 


### PR DESCRIPTION
## Problem

After each daily ingest, the first page visit to a region shows a phantom AO that does not exist in the admin. Refreshing clears it, and all subsequent visitors see correct data until the next ingest.

Specific case: [`/the-fort`](https://regions.f3nation.com/the-fort) shows **Crow's Nest** (phantom) instead of only **Cockpit** (valid) on the first post-ingest load.

This is Next.js `unstable_cache` stale-while-revalidate: the first request after the 15-min TTL expiry serves the previous cached snapshot while a background re-render fetches fresh data. Since low-traffic region pages receive no overnight requests to trigger a natural revalidation, a stale snapshot from during the ingest window (when a workout is briefly present in Supabase between the batch upsert and the end-of-run SQL dedup) can persist all day.

## Fix

Call `revalidateTag` after the full pipeline completes (prune → seed → enrich) so the cache is wiped immediately and the first post-ingest visitor always gets a fresh Supabase query.

## Verification

Cannot be fully verified locally — requires production data and the specific warehouse event causing the phantom. To confirm after deploy:

1. Note the time of the next daily ingest (check Slack notification)
2. Visit [`/the-fort`](https://regions.f3nation.com/the-fort) as the first visitor after the ingest
3. Confirm **Crow's Nest** no longer appears and only **Cockpit** is shown
4. Monitor for 2–3 ingest cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)